### PR TITLE
Update js tutorial for new path-to-regexp

### DIFF
--- a/get-started/single-page-app/website.md
+++ b/get-started/single-page-app/website.md
@@ -105,9 +105,10 @@ const app = express();
 app.use(express.static(join(__dirname, "public")));
 
 // Serve the index page for all other requests
-app.get("/*", (_, res) => {
-  res.sendFile(join(__dirname, "index.html"));
+app.get(/.*/, (req, res) => {
+  res.sendFile(path.join(__dirname, "index.html"));
 });
+
 
 // Listen on port 3000
 app.listen(3000, () => console.log("Application running on port 3000"));

--- a/get-started/single-page-app/website.md
+++ b/get-started/single-page-app/website.md
@@ -99,6 +99,7 @@ Now create a `server.js` file in the root folder of your project. Add the follow
 ```javascript
 const express = require("express");
 const { join } = require("path");
+const path = require("path");
 const app = express();
 
 // Serve static assets from the /public folder


### PR DESCRIPTION
The old server.js code would throw an error as the wildcard was incorrect as of regexp 8 onwards
https://github.com/pillarjs/path-to-regexp#errors