### PR TITLE
Refine on-prem deployment docs (DEV-3546)

### DIFF
--- a/deployment/architecture-guides/on-premises-reference-architecture.md
+++ b/deployment/architecture-guides/on-premises-reference-architecture.md
@@ -71,11 +71,22 @@ architecture-beta
 
 ## Hardware Requirements
 
-| Component | Specification | Count | HA Mechanism | Notes |
-|-----------|--------------|-------|--------------|-------|
-| Kubernetes | 4 vCPUs / 16 GB RAM / 100 GB disk | 3 | N/A | Use a managed Kubernetes service or k3s on VMs |
-| PostgreSQL | 2 vCPUs / 16 GB RAM / 100 GB disk | 2 | Auto failover | Primary-standby setup |
-| Redis | 2 vCPUs / 16 GB RAM / 100 GB disk | 2 | Auto failover | Primary-standby setup |
+The following hardware is suggested for an on-premises Authgear cluster.
+
+### Kubernetes Cluster
+
+- 3× machines, 4 vCPUs / 16 GB RAM / 100 GB disk — nodes in the Kubernetes cluster
+- Use a managed Kubernetes service, or k3s on VMs
+
+### PostgreSQL (HA)
+
+- 1× machine, 2 vCPUs / 16 GB RAM / 100 GB disk — primary
+- 1× machine, 2 vCPUs / 16 GB RAM / 100 GB disk — standby
+
+### Redis (HA)
+
+- 1× machine, 1 vCPU / 16 GB RAM / 100 GB disk — master
+- 1× machine, 1 vCPU / 16 GB RAM / 100 GB disk — replica
 
 {% hint style="info" %}
 Increase the specifications above if you expect high traffic or large numbers of users.
@@ -114,32 +125,74 @@ Components:
 
 ## Firewall Rules
 
-| Direction | Protocol / Port | Source | Destination | Action | Notes |
-|-----------|----------------|--------|-------------|--------|-------|
-| IN | HTTP:80 | `*` | Load Balancer | Allow | Required for Let's Encrypt cert-manager only |
-| IN | HTTPS:443 | `*` | Load Balancer | Allow | Kubernetes ingress |
-| OUT | HTTPS:443 | Kubernetes | Mailer | Allow | Some mailers use SMTP instead |
-| OUT | HTTPS:443 | Kubernetes | SMS Gateway | Allow | |
-| OUT | HTTPS:443 | Kubernetes | WhatsApp | Allow | |
+### Network Firewall (L3/L4)
+
+| Direction | Protocol | Port | Source | Destination | Action | Notes |
+|-----------|----------|------|--------|-------------|--------|-------|
+| IN | TCP | 443 | `*` | Load Balancer | Allow | Kubernetes ingress (HTTPS) |
+| OUT | TCP | 587 | Kubernetes | Mailer (SMTP) | Allow | SMTP submission; use 465 if the mailer requires SMTPS |
+| OUT | TCP | 443 | Kubernetes | Mailer (HTTPS API) | Allow | Only if the mailer uses an HTTPS API instead of SMTP |
+| OUT | TCP | 443 | Kubernetes | SMS Gateway | Allow | |
+| OUT | TCP | 443 | Kubernetes | WhatsApp API | Allow | |
+
+Protocols are transport-layer (TCP/UDP). HTTP and HTTPS are application-layer and should not appear in firewall rules.
+
+### Web Application Firewall (WAF)
+
+#### Hostnames
+
+Each Authgear environment (production, staging, etc.) uses three subdomains:
+
+| Hostname | Purpose | Example |
+|----------|---------|---------|
+| Authgear Endpoint | Serves OAuth 2.0 / OIDC / SAML endpoints for your end-user applications | `auth.example.com` |
+| Authgear Portal | Admin UI where tenant administrators manage users, configure auth flows, and view audit logs | `authgear-portal.example.com` |
+| Portal Login | Authenticates administrators into the Authgear Portal | `accounts.portal.example.com` |
+
+Deploy a separate set of three subdomains per environment. Naming is up to you — for example, a staging environment might use `auth-stg.example.com`, `authgear-portal-stg.example.com`, and `accounts.portal-stg.example.com`.
+
+#### Key Paths on the Authgear Endpoint Host
+
+The Authgear Endpoint host serves the following key paths. Make sure your WAF rules do not block or challenge them.
+
+| Path | Purpose |
+|------|---------|
+| `/.well-known/openid-configuration` | OIDC discovery |
+| `/.well-known/oauth-authorization-server` | OAuth 2.0 authorization server metadata |
+| `/oauth2/authorize` | OAuth 2.0 authorization endpoint |
+| `/oauth2/token` | OAuth 2.0 token endpoint |
+| `/oauth2/userinfo` | OIDC userinfo |
+| `/oauth2/end_session` | OIDC RP-initiated logout |
+| `/oauth2/revoke` | OAuth 2.0 token revocation |
+| `/api/v1/authentication_flows` | Authentication Flow API (for custom auth UIs) |
+| `/_api/admin/graphql` | Admin API (server-to-server) |
+| `/_api/admin/users/import`, `/_api/admin/users/export` | User import / export APIs |
+| `/_resolver/resolve` | Backend forward-auth resolver |
+| `/saml2/metadata/{client_id}` | SAML 2.0 IdP metadata (if SAML is in scope) |
+| `/saml2/login/{client_id}`, `/saml2/logout/{client_id}` | SAML 2.0 SSO / SLO endpoints |
+
+In addition, the Authgear Endpoint host serves AuthUI — the end-user login, signup, and settings pages — at routes such as `/login`, `/signup`, `/settings`, and `/reset_password`, plus static assets with versioned filenames.
+
+The Authgear Portal and Portal Login hosts also serve a single-page app with many dynamic API and asset requests.
 
 ## Logs, Monitoring, and Alerts
 
+### Metrics and Application Logs
+
+Authgear exports metrics and application logs via OpenTelemetry (OTel). Collect and store them with any OTel-compatible stack. We recommend the [LGTM stack](https://grafana.com/about/grafana-stack/) — Loki (logs), Grafana (dashboards), Tempo (traces), and Mimir or Prometheus (metrics) — but any equivalent toolchain works.
+
 ### Access Logs
 
-Access logs are available from the Kubernetes ingress controller and can be viewed in Grafana.
-
-### Application Logs
-
-Application logs are available from Kubernetes pod logs and can be viewed in Grafana.
+Access logs are produced by the Kubernetes ingress controller. Ship them to your log store alongside application logs.
 
 ### Audit Logs
 
-Audit logs are accessible from the Authgear Portal or by querying the database directly.
+Audit logs are viewable in the Authgear Portal and are persisted in the PostgreSQL database. Include the database in your backup policy to retain audit history.
 
 ### Infrastructure Monitoring
 
-Monitor infrastructure health using your on-premises monitoring stack.
+Monitor node, database, and Redis health using your on-premises monitoring stack (e.g., Prometheus node-exporter, postgres-exporter, redis-exporter scraped into Mimir/Prometheus).
 
 ### Backups
 
-Database backups are not automated. Set up a backup schedule and procedure that meets your recovery requirements.
+Database backups are not automated by Authgear. Configure a backup schedule and restore procedure that meets your recovery requirements (RPO/RTO).

--- a/deployment/architecture-guides/on-premises-reference-architecture.md
+++ b/deployment/architecture-guides/on-premises-reference-architecture.md
@@ -135,8 +135,6 @@ Components:
 | OUT | TCP | 443 | Kubernetes | SMS Gateway | Allow | |
 | OUT | TCP | 443 | Kubernetes | WhatsApp API | Allow | |
 
-Protocols are transport-layer (TCP/UDP). HTTP and HTTPS are application-layer and should not appear in firewall rules.
-
 ### Web Application Firewall (WAF)
 
 #### Hostnames


### PR DESCRIPTION
## Summary

Refines the on-premises reference architecture page based on feedback from tung in DEV-3546 and requirements gathered while preparing deployment docs for a customer.

### Hardware Requirements
Split the single table into three subsections — Kubernetes Cluster, PostgreSQL (HA), Redis (HA) — so each HA tier is obvious.

### Firewall Rules
- Split into **Network Firewall (L3/L4)** and **Web Application Firewall (WAF)**.
- Network firewall now uses transport-layer protocols (TCP/UDP) instead of HTTP/HTTPS.
- SMTP mailer outbound uses TCP 587 (with a note on 465 for SMTPS).
- Dropped inbound port 80 — Authgear does not use the HTTP-01 ACME challenge.
- WAF section lists the three per-environment subdomains (Authgear Endpoint, Authgear Portal, Portal Login) and the key paths served on the Endpoint host, verified against the current [API reference](https://docs.authgear.com/reference/apis).

### Logs, Monitoring, and Alerts
Rewritten around the actual capabilities: Authgear exports metrics and application logs via OpenTelemetry, audit logs are viewable in the Portal and persisted in PostgreSQL, and we recommend the LGTM stack (Loki, Grafana, Tempo, Mimir/Prometheus) for collection.

## Test plan

- [ ] Preview the page in GitBook and confirm tables render correctly
- [ ] Confirm firewall rule wording with Calvin (outbound destinations, SMTP vs HTTPS mailer)
- [ ] Confirm WAF path list with infra (Tung) before sharing with customers