### PR TITLE
Fix broken internal links flagged by Ahrefs

### DIFF
--- a/admin/user-profiles/access-user-profiles.md
+++ b/admin/user-profiles/access-user-profiles.md
@@ -233,7 +233,7 @@ The following are some attributes that are usually in the userInfo object. Other
 
 | Key         | Type      | Description                                                                                                                                                                                                                                         |
 | ----------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| isAnonymous | _boolean_ | Indicate if the user is anonymous, i.e. no [identity](../../get-started/core-concepts/user-identity-and-authenticator.md#identity) or [authenticator](../../get-started/core-concepts/user-identity-and-authenticator.md#authenticator) is provided |
+| isAnonymous | _boolean_ | Indicate if the user is anonymous, i.e. no [identity](../../concepts/user-identity-and-authenticator.md#identity) or [authenticator](../../concepts/user-identity-and-authenticator.md#authenticator) is provided |
 | isVerified  | _boolean_ | Indicate if the user completed the verification requirement                                                                                                                                                                                         |
 | sub         | _string_  | Unique identifier of the user in your Authgear project                                                                                                                                                                                              |
 

--- a/customization/ui-customization/custom-ui/add-custom-login-signup-ui-to-native-apps.md
+++ b/customization/ui-customization/custom-ui/add-custom-login-signup-ui-to-native-apps.md
@@ -6,7 +6,7 @@ description: This guide shows how to use Custom Login/Signup pages UI in Native 
 
 Implementing custom login and signup screens in any native application (Flutter, React Native, Kotlin, or iOS) doesn't require much change to the code for your existing native apps that use Authgear.
 
-At the moment, we don't support direct interaction between your native code and the Authentication Flow API that powers custom UIs. That means you'll need to use the platform-specific [SDKs](broken-reference/) we already provide and call the authenticate method to start the authentication flow.
+At the moment, we don't support direct interaction between your native code and the Authentication Flow API that powers custom UIs. That means you'll need to use the platform-specific [SDKs](../../../get-started/start-building.md) we already provide and call the authenticate method to start the authentication flow.
 
 In this guide, we'll teach you how to implement custom authentication UIs in a Flutter app using the Flutter SDK and Authentication Flow API.
 

--- a/customization/ui-customization/custom-ui/manually-link-oauth-provider-using-account-management-api.md
+++ b/customization/ui-customization/custom-ui/manually-link-oauth-provider-using-account-management-api.md
@@ -102,7 +102,7 @@ The account manage API requires a user's valid access token to work. Hence, you 
 
 Set up your application to allow users to log in using Authgear and obtain an access token.
 
-See our [Getting Started](broken-reference) section for a detailed guide for your preferred programming language or framework.
+See our [Getting Started](../../../get-started/start-building.md) section for a detailed guide for your preferred programming language or framework.
 
 ### Step 2: Initiate OAuth Link Flow
 

--- a/get-started/5-minute-guide.md
+++ b/get-started/5-minute-guide.md
@@ -59,7 +59,7 @@ The **Security** section of the User Settings page has the following options:
 * **Signed-in device:** from this page, the user can view browsers and devices that their account is currently signed in on.
 * **Advanced Settings:** contains additional settings. For example, when you enable [Account Deletion](../admin/user-management/account-deletion.md) for your project, users can click on this link to access the **Delete Account** button.
 
-You can learn more about the User Settings page [here](../customization/ui-customization/built-in-ui/auth-ui.md).
+You can learn more about the User Settings page [here](../customization/ui-customization/built-in-ui/user-settings.md).
 
 ### 5. Integrate Authgear with Your Application or Website
 

--- a/get-started/start-building.md
+++ b/get-started/start-building.md
@@ -21,7 +21,7 @@ There are 3 different high-level approaches to integrating Authgear with your ap
 
 ### Client-side SDKs
 
-Client-side SDKs are designed for developers to quickly implement authentication with Auth UI on your web and mobile applications. After login, it returns the user data for your apps. It can open a hosted [pre-built account settings page](../customization/ui-customization/built-in-ui/auth-ui.md) for the user to manage their own account. The SDKs manage session token storage automatically and have built-in token ownership protection ([DPoP](https://oauth.net/2/dpop/)) against stolen refresh tokens.
+Client-side SDKs are designed for developers to quickly implement authentication with Auth UI on your web and mobile applications. After login, it returns the user data for your apps. It can open a hosted [pre-built account settings page](../customization/ui-customization/built-in-ui/user-settings.md) for the user to manage their own account. The SDKs manage session token storage automatically and have built-in token ownership protection ([DPoP](https://oauth.net/2/dpop/)) against stolen refresh tokens.
 
 **Check out the following guides for your specific framework:**
 
@@ -90,5 +90,5 @@ If you wish to use a custom UI instead of the pre-built UI for signup and login,
 
 When implementing identity management for your enterprise software, Authgear provides robust single sign-on (SSO) capabilities that seamlessly connect your workforce. Enterprise applications typically support standard authentication protocols like OpenID Connect (OIDC) and Security Assertion Markup Language (SAML)
 
-* [Integration with OIDC Protocol](../how-to-guide/single-sign-on/oidc-provider.md)
-* [Integration with SAML 2.0 Protocol](../how-to-guide/single-sign-on/single-sign-on-with-saml/)
+* [Integration with OIDC Protocol](../authentication-and-access/single-sign-on/oidc-provider.md)
+* [Integration with SAML 2.0 Protocol](../authentication-and-access/single-sign-on/single-sign-on-with-saml/)

--- a/migration/bulk-migration.md
+++ b/migration/bulk-migration.md
@@ -129,7 +129,7 @@ Now that you have successfully imported your users to Authgear, you can start us
 To do this, implement a middleware and server-side logic that uses Authgear session.
 
 {% hint style="info" %}
-**Note:** Deploying the middleware and server-side logic that uses Authgear session means all users will be logged out and be required to log in again [using Authgear's authentication flow](broken-reference).
+**Note:** Deploying the middleware and server-side logic that uses Authgear session means all users will be logged out and be required to log in again [using Authgear's authentication flow](../get-started/start-building.md).
 {% endhint %}
 
 The following is an example of a simple Express.js application with a middleware that uses Authgear session:


### PR DESCRIPTION
## Summary

Fixes 6 stale internal references found by Ahrefs in `authgear_07-may-2026_page-has-links-to-broken_2026-05-07_15-58-40.csv`. The targets had moved or been renamed; GitBook surfaced them as `github.com/authgear/docs/blob/main/...` 404s in rendered HTML.

| File | Old target | New target |
|---|---|---|
| `get-started/start-building.md` | `customization/ui-customization/built-in-ui/auth-ui.md` | `.../built-in-ui/user-settings.md` |
| `get-started/start-building.md` | `how-to-guide/single-sign-on/oidc-provider.md` | `authentication-and-access/single-sign-on/oidc-provider.md` |
| `get-started/start-building.md` | `how-to-guide/single-sign-on/single-sign-on-with-saml/` | `authentication-and-access/single-sign-on/single-sign-on-with-saml/` |
| `get-started/5-minute-guide.md` | `customization/ui-customization/built-in-ui/auth-ui.md` | `.../built-in-ui/user-settings.md` |
| `customization/ui-customization/custom-ui/add-custom-login-signup-ui-to-native-apps.md` | `broken-reference/` (SDKs) | `get-started/start-building.md` |
| `customization/ui-customization/custom-ui/manually-link-oauth-provider-using-account-management-api.md` | `broken-reference` (Getting Started) | `get-started/start-building.md` |
| `admin/user-profiles/access-user-profiles.md` | `get-started/core-concepts/user-identity-and-authenticator.md#identity\|#authenticator` | `concepts/user-identity-and-authenticator.md#identity\|#authenticator` |

The `migration/bulk-migration.md` `broken-reference` was not in the Ahrefs report but was repointed to `get-started/start-building.md` for consistency.

## Notes

External 403s in the same Ahrefs report (npmjs.com, datatracker.ietf.org RFC pages, central.sonatype.com, developer.apple.com) were left as-is — those URLs work in browsers and 403 only against crawlers.

## Test plan

- [ ] Verify each updated link resolves on the rendered docs site after publish
- [ ] Confirm `#identity` and `#authenticator` anchors in `concepts/user-identity-and-authenticator.md` still match the H2 headings (verified locally)
- [ ] Re-run Ahrefs broken-link scan to confirm the 5 internal entries clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)