### PR TITLE
Document admin reset account lockout (DEV-3508)

### DIFF
--- a/api-reference/apis/admin-api/api-queries-and-mutations.md
+++ b/api-reference/apis/admin-api/api-queries-and-mutations.md
@@ -404,6 +404,102 @@ The `getUser` and `getUsers` queries are a collection of Admin API queries for g
 
 Learn more about all the queries in this collection [here](retrieving-users-using-admin-api.md).
 
+### 1.8 User.accountLockout
+
+The `accountLockout` field on the `User` type returns the current account lockout state for a user. Select this field through any query that returns a `User` (for example, the `node` query in 1.3, or the `getUser` / `getUsers` queries in 1.7).
+
+**Schema:**
+
+```graphql
+type AccountLockout {
+  lockoutType: LockoutType!
+  isLocked: Boolean!
+  lockedUntil: DateTime
+  lockedIPs: [LockedIP!]!
+}
+
+type LockedIP {
+  ipAddress: String!
+  lockedUntil: DateTime!
+}
+
+enum LockoutType {
+  per_user
+  per_user_per_ip
+}
+```
+
+The response shape depends on the project's configured Lockout Type:
+
+* For `per_user`, `lockedUntil` is the time the lock expires (UTC) and `lockedIPs` is empty.
+* For `per_user_per_ip`, `lockedUntil` is `null` and `lockedIPs` lists each currently locked IP with its own expiry, ordered by expiry descending.
+
+**Example:**
+
+{% tabs %}
+{% tab title="Query" %}
+```graphql
+query {
+  node(id: "<ENCODED USER ID>") {
+    ... on User {
+      id
+      accountLockout {
+        lockoutType
+        isLocked
+        lockedUntil
+        lockedIPs {
+          ipAddress
+          lockedUntil
+        }
+      }
+    }
+  }
+}
+```
+{% endtab %}
+
+{% tab title="Response (per_user)" %}
+```json
+{
+  "data": {
+    "node": {
+      "id": "VXNlcjowNGUyJJO4Mi04NmEzLTRjYjItOGQxNy14ZWU0Y2FlNzQ5Kse",
+      "accountLockout": {
+        "lockoutType": "per_user",
+        "isLocked": true,
+        "lockedUntil": "2026-05-15T14:53:50Z",
+        "lockedIPs": []
+      }
+    }
+  }
+}
+```
+{% endtab %}
+
+{% tab title="Response (per_user_per_ip)" %}
+```json
+{
+  "data": {
+    "node": {
+      "id": "VXNlcjowNGUyJJO4Mi04NmEzLTRjYjItOGQxNy14ZWU0Y2FlNzQ5Kse",
+      "accountLockout": {
+        "lockoutType": "per_user_per_ip",
+        "isLocked": true,
+        "lockedUntil": null,
+        "lockedIPs": [
+          { "ipAddress": "192.0.2.10", "lockedUntil": "2026-05-15T14:53:50Z" },
+          { "ipAddress": "192.0.2.42", "lockedUntil": "2026-05-15T14:31:18Z" }
+        ]
+      }
+    }
+  }
+}
+```
+{% endtab %}
+{% endtabs %}
+
+See [Account Lockout](../../rate-limits/account-lockout.md) for an overview of the feature and how to unlock a user.
+
 ## 2. Mutations
 
 With mutations, you can modify data from your application using the Admin API GraphQL. For example, you can use mutation to update
@@ -2151,3 +2247,51 @@ mutation {
 ```
 {% endtab %}
 {% endtabs %}
+
+### 2.39 resetAccountLockout
+
+The `resetAccountLockout` mutation clears all account lockout state for a user, allowing them to authenticate again immediately without waiting for the lockout duration to elapse. The mutation clears lockout state across all authenticator types that participate in account lockout (password, TOTP, OOB OTP, recovery code). For `per_user` lockouts the global lock is cleared. For `per_user_per_ip` lockouts every IP-specific lock for the user is cleared. If account lockout is not configured or not enabled, the mutation succeeds with no effect.
+
+**Schema:**
+
+```graphql
+resetAccountLockout(input: ResetAccountLockoutInput!): ResetAccountLockoutPayload!
+```
+
+**Example:**
+
+{% tabs %}
+{% tab title="Query" %}
+```graphql
+mutation {
+  resetAccountLockout(input: {userID: "<ENCODED USER ID>"}) {
+    user {
+      id
+      accountLockout {
+        isLocked
+      }
+    }
+  }
+}
+```
+{% endtab %}
+
+{% tab title="Response" %}
+```json
+{
+  "data": {
+    "resetAccountLockout": {
+      "user": {
+        "id": "VXNlcjowNGUyJJO4Mi04NmEzLTRjYjItOGQxNy14ZWU0Y2FlNzQ5Kse",
+        "accountLockout": {
+          "isLocked": false
+        }
+      }
+    }
+  }
+}
+```
+{% endtab %}
+{% endtabs %}
+
+See [Account Lockout](../../rate-limits/account-lockout.md) for an overview of the feature, including how to unlock a user from the Authgear Portal.

--- a/api-reference/rate-limits/account-lockout.md
+++ b/api-reference/rate-limits/account-lockout.md
@@ -64,3 +64,58 @@ Under this section you can select the types of authenticator where failed login 
 * Passwordless via Phone/Email
 * Authenticator App (TOTP)
 * Recovery codes
+
+### How to Unlock a User from the Portal
+
+An administrator can unlock a locked user immediately without waiting for the lockout duration to elapse. In the Authgear Portal, navigate to **Users**, open the affected user, and switch to the **Account Status** tab. Under the **Account Lockout** section you will see a message such as "This user is locked out due to failed sign-in attempts." along with the time the lock will automatically expire. Click **Reset account lockout** to clear the lock immediately.
+
+The **Account Lockout** section is only shown when the user is currently locked.
+
+### Unlocking a User via the Admin API
+
+You can also inspect a user's lockout state and clear it programmatically using the Admin GraphQL API. This is useful for automating customer-support workflows or building internal tooling.
+
+Use the `accountLockout` field on the `User` type to check whether a user is currently locked:
+
+```graphql
+query {
+  node(id: "<ENCODED USER ID>") {
+    ... on User {
+      id
+      accountLockout {
+        lockoutType
+        isLocked
+        lockedUntil
+        lockedIPs {
+          ipAddress
+          lockedUntil
+        }
+      }
+    }
+  }
+}
+```
+
+The response shape depends on the configured **Lockout Type**:
+
+* For `per_user`, `lockedUntil` is the time the lock expires (UTC) and `lockedIPs` is empty.
+* For `per_user_per_ip`, `lockedUntil` is `null` and `lockedIPs` lists each currently locked IP with its own expiry, ordered by expiry descending.
+
+To unlock the user immediately, call the `resetAccountLockout` mutation:
+
+```graphql
+mutation {
+  resetAccountLockout(input: { userID: "<ENCODED USER ID>" }) {
+    user {
+      id
+      accountLockout {
+        isLocked
+      }
+    }
+  }
+}
+```
+
+The mutation clears lockout state across all participating authenticator types (password, TOTP, OOB OTP, recovery code). For `per_user_per_ip` lockouts it clears every IP-specific lock for the user. After the call succeeds, the user can authenticate immediately from any IP. If account lockout is not configured or not enabled, the mutation succeeds with no effect.
+
+See [API Queries and Mutations](../apis/admin-api/api-queries-and-mutations.md) for the full Admin API reference.

--- a/api-reference/rate-limits/account-lockout.md
+++ b/api-reference/rate-limits/account-lockout.md
@@ -69,8 +69,6 @@ Under this section you can select the types of authenticator where failed login 
 
 An administrator can unlock a locked user immediately without waiting for the lockout duration to elapse. In the Authgear Portal, navigate to **Users**, open the affected user, and switch to the **Account Status** tab. Under the **Account Lockout** section you will see a message such as "This user is locked out due to failed sign-in attempts." along with the time the lock will automatically expire. Click **Reset account lockout** to clear the lock immediately.
 
-The **Account Lockout** section is only shown when the user is currently locked.
-
 ### Unlocking a User via the Admin API
 
 You can also inspect a user's lockout state and clear it programmatically using the Admin GraphQL API. This is useful for automating customer-support workflows or building internal tooling.


### PR DESCRIPTION
## Summary

Documents the new admin "Reset Account Lockout" capability shipped in [DEV-3508](https://linear.app/authgear/issue/DEV-3508/admin-reset-account-lockout-unlock-user):

- `api-reference/rate-limits/account-lockout.md` — adds **How to Unlock a User from the Portal** (Account Status tab walkthrough) and **Unlocking a User via the Admin API** sections.
- `api-reference/apis/admin-api/api-queries-and-mutations.md` — adds query subsection `1.8 User.accountLockout` (with `per_user` and `per_user_per_ip` response examples) and mutation subsection `2.39 resetAccountLockout`.

## Follow-ups (separate)

- [DEV-3593](https://linear.app/authgear/issue/DEV-3593/emit-audit-log-entry-for-resetaccountlockout-mutation) — backend currently does not emit an audit log entry when the mutation is invoked. Once that lands, the audit-log reference page and the new "Unlocking a User via the Admin API" section will need entries.
- Portal screenshot for the new Reset account lockout button (Account Status tab) still needs to be added under `.gitbook/assets/` and referenced from the Portal section.
- The `reference/` (old) vs `api-reference/` (current) duplicate tree is a separate cleanup tracked outside this PR.

## Test plan

- [ ] Render the two pages in GitBook preview and confirm the new sections appear under the right parents.
- [ ] Verify GraphQL code blocks render correctly inside `{% tabs %}` blocks.
- [ ] Verify cross-links resolve:
  - From `api-reference/rate-limits/account-lockout.md` → `../apis/admin-api/api-queries-and-mutations.md`
  - From `api-reference/apis/admin-api/api-queries-and-mutations.md` → `../../rate-limits/account-lockout.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)