### PR TITLE
Fix mislabeled tab and inconsistent redirect in OAuth link/unlink guide

### DIFF
--- a/authentication-and-access/social-enterprise-login-providers/link-and-unlink-social-enterprise-provider-with-the-sdk.md
+++ b/authentication-and-access/social-enterprise-login-providers/link-and-unlink-social-enterprise-provider-with-the-sdk.md
@@ -183,7 +183,7 @@ The options are the same as `startLinkOAuth()`. Use a different `state` value so
 When the user returns to your `redirectURI`, finish the action. Read the `state` query parameter to choose between `finishLinkOAuth()` and `finishUnlinkOAuth()`, then send the user back to your account details page.
 
 {% tabs %}
-{% tab title="First Tab" %}
+{% tab title="React" %}
 ```tsx
 import { useEffect } from "react";
 import authgear from "@authgear/web";
@@ -206,7 +206,8 @@ function OAuthCallback() {
         } else if (state === "unlink_oauth") {
           await authgear.finishUnlinkOAuth();
         }
-        window.location.replace("/members");
+        // Both actions are done. Return to the account details page.
+        window.location.replace("/account");
       } catch (err) {
         console.error(err);
       }
@@ -239,8 +240,8 @@ function OAuthCallback() {
     } else if (state === "unlink_oauth") {
       await authgear.finishUnlinkOAuth();
     }
-    // Both actions are done. Return to the members portal.
-    window.location.replace("/members");
+    // Both actions are done. Return to the account details page.
+    window.location.replace("/account");
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
Two small fixes to the **Link and Unlink Social/Enterprise Provider with the SDK** page that slipped in during publishing:

1. **Step 5 tab label** — the React tab was titled "First Tab". Renamed to "React" to match the JavaScript tab next to it.
2. **Redirect consistency** — both Step 5 samples redirected to `/members` while the rest of the guide refers to an "account details page". Changed the redirect to `/account` and added the missing explanatory comment in the React tab.

No content or code-logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)