### PR TITLE
docs: update Azure AD page to Microsoft Entra ID naming and links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -78,7 +78,7 @@
     * [Connect Mobile Apps to WeChat](authentication-and-access/social-enterprise-login-providers/social-login-providers/wechat-mobile.md)
     * [Connect Websites to WeChat](authentication-and-access/social-enterprise-login-providers/social-login-providers/wechat-web.md)
   * [Enterprise Login Providers](authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/README.md)
-    * [Connect Apps to Azure Active Directory](authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/azureadv2.md)
+    * [Connect Apps to Microsoft Entra ID (Azure AD)](authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/azureadv2.md)
     * [Connect Apps to Microsoft AD FS](authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/adfs.md)
     * [Connect Apps to Azure AD B2C](authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/azureadb2c.md)
   * [Force Social/Enterprise Login Providers to Show Login Screen](authentication-and-access/social-enterprise-login-providers/force-social-enterprise-login-providers-to-show-login-screen.md)

--- a/authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/azureadv2.md
+++ b/authentication-and-access/social-enterprise-login-providers/enterprise-login-providers/azureadv2.md
@@ -1,19 +1,23 @@
-# Connect Apps to Azure Active Directory
+# Connect Apps to Microsoft Entra ID (Azure AD)
+
+{% hint style="info" %}
+**Microsoft Entra ID** is the new name for **Azure Active Directory (Azure AD)**. Microsoft renamed the product in 2023; existing Azure AD configurations and integrations continue to work without change. This page uses the current name, but you may still see "Azure AD" in older portals or documentation.
+{% endhint %}
 
 ## Prerequisite
 
-1. Create an Azure Active Directory (Azure AD) account [here](https://azure.microsoft.com/free)
-2. Setup a tenant by completing [Quickstart: Set up a tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant)
-3. Register an application by completing [Quickstart: Register an application with the Microsoft identity platform](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app)
-4.  Choose "Supported account type", the following options are supported:
+1. Create a Microsoft Entra ID account [here](https://azure.microsoft.com/free)
+2. Setup a tenant by completing [Quickstart: Set up a tenant](https://learn.microsoft.com/en-us/entra/fundamentals/create-new-tenant)
+3. Register an application by completing [Quickstart: Register an application with the Microsoft identity platform](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app)
+4.  Choose "Supported account types", the following options are supported:
 
-    * Accounts in this organizational directory only (Contoso AD (dev) only - Single tenant)
-    * Accounts in this organizational directory (Any Azure AD directory - Multitenant)
-    * Accounts in this organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)
+    * Single tenant only - &lt;your tenant&gt; (Accounts in this organizational directory only)
+    * Multiple Entra ID tenants (Accounts in any organizational directory - Multitenant)
+    * Any Entra ID tenant + Personal Microsoft accounts (Multitenant and personal Microsoft accounts, e.g. Skype, Xbox)
 
-    "Personal Microsoft accounts only" is not supported yet. Remember the account type chosen as this affects the configuration on Authgear portal
-5. Configure "Redirect URI" with `https://<YOUR_AUTHGEAR_ENDPOINT>/sso/oauth2/callback/azureadv2`
-6. Follow [this](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app#add-a-client-secret) section to add a client secret. Remember to record the secret value when you add the client secret, as it will not be displayed again. This will be needed for configure OAuth client in Authgear.
+    "Personal accounts only" is not supported yet. Remember the account type chosen as this affects the configuration on Authgear portal
+5. Configure "Redirect URI" with `https://<YOUR_AUTHGEAR_ENDPOINT>/sso/oauth2/callback/azureadv2`. See [How to add a redirect URI to your application](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-redirect-uri).
+6. Follow [this](https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials?tabs=client-secret) section to add a client secret. Remember to record the secret value when you add the client secret, as it will not be displayed again. This will be needed for configure OAuth client in Authgear.
 
 {% hint style="info" %}
 Redirect URI has the form of `/sso/oauth2/callback/:oauth_provider_alias`. The `oauth_provider_alias` is the OAuth Provider Alias configured for this provider in Authgear Portal.
@@ -23,16 +27,16 @@ Redirect URI has the form of `/sso/oauth2/callback/:oauth_provider_alias`. The `
 
 1. In the portal, go to **Authentication > Social / Enterprise Login**.
 2. Enable **Sign in with Microsoft**
-3. Fill in **Client ID** with **Application (client) ID** of your just created Azure AD application.
-4. Fill in **Client Secret**" with the secret you get after creating a client secret for your Azure AD application.
+3. Fill in **Client ID** with **Application (client) ID** of your just created Microsoft Entra ID application.
+4. Fill in **Client Secret**" with the secret you get after creating a client secret for your Microsoft Entra ID application.
 5. For **Tenant** field:
-   * If **single tenant (first option)** is chosen, fill in the **Directory (tenant) ID** of your Azure AD application.
+   * If **single tenant (first option)** is chosen, fill in the **Directory (tenant) ID** of your Microsoft Entra ID application.
    * If **multi tenant (second option)** is chosen, fill in the string literal `organizations`.
    * If **multi tenant and personal account (third option)** is chosen, fill in the string literal `common`.
 6. **Save** the settings.
 
-🎉 Done! You have just added Azure Active Directory (Azure AD) Login to your apps!
+🎉 Done! You have just added Microsoft Entra ID (Azure AD) Login to your apps!
 
 ### Force Login page
 
-Azure Active Directory automatically logs in to the same account without requiring a username and password. To prevent this behaviour, you can use the `prompt=login` parameter to force Azure Active Directory to show the login page. See our [guide on using the prompt=login parameter](../force-social-enterprise-login-providers-to-show-login-screen.md) in Authgear SDKs to learn more.
+Microsoft Entra ID automatically logs in to the same account without requiring a username and password. To prevent this behaviour, you can use the `prompt=login` parameter to force Microsoft Entra ID to show the login page. See our [guide on using the prompt=login parameter](../force-social-enterprise-login-providers-to-show-login-screen.md) in Authgear SDKs to learn more.


### PR DESCRIPTION
## What

Refreshes the **Connect Apps to Azure Active Directory** enterprise login provider page (`azureadv2.md`) to reflect Microsoft's current branding and documentation.

## Why

The page was technically accurate but outdated:
- Microsoft renamed **Azure Active Directory (Azure AD)** to **Microsoft Entra ID** in mid-2023 ([official announcement](https://learn.microsoft.com/en-us/entra/fundamentals/new-name)). The portal a customer sees today says "Microsoft Entra ID."
- All Microsoft doc links pointed at the retired `docs.microsoft.com/.../active-directory/...` paths.
- The "Supported account types" option labels no longer matched the current portal.

## Changes

- Retitle to **Connect Apps to Microsoft Entra ID (Azure AD)** — keeps the old name discoverable for existing customers.
- Add an info hint explaining the rename (existing Azure AD setups keep working).
- Update all Microsoft links to current `learn.microsoft.com/entra` URLs (each verified live):
  - Tenant: `entra/fundamentals/create-new-tenant`
  - Register app: `entra/identity-platform/quickstart-register-app`
  - Redirect URI: `entra/identity-platform/how-to-add-redirect-uri` (new dedicated link)
  - Client secret: `entra/identity-platform/how-to-add-credentials?tabs=client-secret`
- Update "Supported account types" labels to match the current portal.
- Update body references from Azure AD → Microsoft Entra ID.
- Update the `SUMMARY.md` nav entry to match.

No functional/configuration changes — the redirect URI format, tenant-field logic, and portal flow are unchanged.