### PR TITLE
docs: clarify Docker Compose example is for local dev, not production

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -224,9 +224,9 @@
 
 ## Deployment
 
-* [Run with Docker](deployment/local-development/local.md)
 * [Deploy with Helm chart](deployment/production-deployment/helm.md)
 * [Authenticating HTTP request with Nginx](deployment/production-deployment/auth-nginx.md)
+* [Run locally with Docker Compose](deployment/local-development/local.md)
 * [Configuration](deployment/configuration/README.md)
   * [Environment Variables](deployment/configuration/env.md)
   * [authgear.yaml](deployment/configuration/authgear.yaml.md)

--- a/deployment/local-development/local.md
+++ b/deployment/local-development/local.md
@@ -1,12 +1,20 @@
 ---
-description: How to run locally with Docker.
+description: How to run Authgear locally with Docker Compose.
 ---
 
-# Run with Docker
+# Run locally with Docker Compose
 
 Authgear is available as a Docker image. It depends on PostgreSQL (with pg\_partman enabled) and Redis.
 
-To simplify running Authgear locally with Docker, we provide an example repository that includes a complete setup and step-by-step instructions.
+To make it easy to try Authgear on your own machine, we provide an example repository with a complete Docker Compose setup and step-by-step instructions.
+
+{% hint style="info" %}
+This example is meant for local development and trying things out. It ships with default credentials and `DEV_MODE` turned on, so it works out of the box but isn't safe to expose to the internet.
+
+Production deployments aren't off the table if you know what you're doing, but the defaults aren't ready to ship as-is. At minimum, swap out the credentials in the `env` file (database passwords, secret keys, JWT secrets), set the origins to your real domain, and turn off `DEV_MODE`.
+
+For most production setups, we recommend [Deploy with Helm chart](../production-deployment/helm.md) instead.
+{% endhint %}
 
 **Clone the example repo and follow the included** `README.md`: \
 [https://github.com/authgear/authgear-example-docker-compose](https://github.com/authgear/authgear-example-docker-compose)


### PR DESCRIPTION
## Summary

The "Run with Docker" page sat at the top of the **Deployment** section next to the production guides, and its wording read as a deployment path with no caveat. Meanwhile the upstream [authgear-example-docker-compose](https://github.com/authgear/authgear-example-docker-compose) repo (PR #4, commits `0332dbd` and `fa83875`) added a clear warning that the setup is for local development/demos only — default credentials, `DEV_MODE` on by default.

This aligns the docs with that intent.

## Changes

- Retitle **Run with Docker** → **Run locally with Docker Compose** (and matching description).
- Add an info callout: explains it's for local dev, that production is still possible with the right changes (swap credentials in `env`, set origins to a real domain, turn off `DEV_MODE`), and recommends the Helm chart for production.
- Move the page below the production deployment guides in `SUMMARY.md`.

## Related

- Upstream: authgear/authgear-example-docker-compose#4