### PR TITLE
Update Angular quickstart for standalone components + Angular 22 / SDK v5

### DIFF
--- a/get-started/single-page-app/angular.md
+++ b/get-started/single-page-app/angular.md
@@ -14,6 +14,10 @@ Follow this :clock1: **15 minutes** tutorial to create a simple app using Angula
 **Check out and clone** [<mark style="color:orange;">**the Sample Project on GitHub**</mark>](https://github.com/authgear/authgear-example-angular)**.**
 {% endhint %}
 
+{% hint style="info" %}
+This tutorial targets **Angular 17 and above**, which use [standalone components](https://angular.dev/guide/components) and bootstrap the app without `NgModule`. The sample project is built with Angular 22 (standalone, zoneless change detection). If you are on an older Angular version that still uses `NgModule`, adapt the steps accordingly.
+{% endhint %}
+
 **Table of Content**
 
 * [Setup Application in Authgear](angular.md#setup-application-in-authgear)
@@ -70,12 +74,12 @@ npm install -g @angular/cli
 ```
 
 {% hint style="info" %}
-For Windows clients, please find your reference in [https://angular.io/guide/setup-local](https://angular.io/guide/setup-local) for more information on installing the Angular CLI.
+For Windows clients, please find your reference in [https://angular.dev/tools/cli/setup-local](https://angular.dev/tools/cli/setup-local) for more information on installing the Angular CLI.
 {% endhint %}
 
 #### Create initial workspace
 
-Run the following cli command to create a new workspace and initial app called `my-app` with a routing module generated.
+Run the following cli command to create a new workspace and initial app called `my-app` with routing enabled.
 
 ```bash
 # Create a workspace called my-app
@@ -83,6 +87,16 @@ ng new my-app --routing --defaults
 # Move into the project directory
 cd my-app
 ```
+
+On Angular 17+, this scaffolds a standalone application. The important generated files are:
+
+* `src/main.ts` — bootstraps the app with `bootstrapApplication(AppComponent, appConfig)`
+* `src/app/app.config.ts` — the application providers (this is where we will configure Authgear and the router)
+* `src/app/app.routes.ts` — the route definitions
+
+{% hint style="info" %}
+Newer versions of the Angular CLI generate component and service files **without** the `.component` / `.service` suffix (for example `app.ts` and class `App` instead of `app.component.ts` and class `AppComponent`). This tutorial and the sample project use the suffixed names. The code is identical either way — just match the file names and class names your CLI generated.
+{% endhint %}
 
 #### Edit script for launching the app
 
@@ -120,40 +134,49 @@ Run the following command within your Angular project directory to install the A
 npm install --save-exact @authgear/web
 ```
 
-In `src/app/app.component.ts` , import `authgear` and call the `configure` function to initialize an Authgear instance on application loads.
+Authgear must be configured **before** any other SDK call (for example `finishAuthentication()` or `fetchUserInfo()`), and configuration is asynchronous. The cleanest way to guarantee this in Angular is to run `authgear.configure()` during app initialization, so the app only renders after Authgear is ready.
+
+In `src/app/app.config.ts`, register an app initializer that calls `configure`:
 
 ```typescript
-// src/app/app.component.ts
-import { Component, OnInit } from '@angular/core';
+// src/app/app.config.ts
+import {
+  ApplicationConfig,
+  provideAppInitializer,
+  provideBrowserGlobalErrorListeners,
+} from '@angular/core';
+import { provideRouter } from '@angular/router';
 import authgear from '@authgear/web';
 
-@Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
-})
-export class AppComponent implements OnInit {
-  // configure Authgear container instance
-  initAuthgear(): Promise<void> {
-    return authgear.configure({
-      endpoint: '<your_app_endpoint>',
-      clientID: '<your_client_id>',
-      sessionType: 'refresh_token',
-    });
-  }
+import { routes } from './app.routes';
 
-  ngOnInit(): void {
-    this.initAuthgear().catch((e) => {
-      // Error handling
-      console.log(e);
-    });
-  }
-}
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideBrowserGlobalErrorListeners(),
+    provideRouter(routes),
+    // Configure Authgear before the app renders. configure() must complete
+    // before any other SDK call, so blocking bootstrap here avoids a race in
+    // which the redirect page or home page runs before the SDK is ready.
+    provideAppInitializer(async () => {
+      try {
+        await authgear.configure({
+          endpoint: '<your_app_endpoint>',
+          clientID: '<your_client_id>',
+          sessionType: 'refresh_token',
+        });
+      } catch (e) {
+        // Don't block bootstrap if Authgear is unreachable; the app will
+        // render in the logged-out state and login can be retried.
+        console.error(e);
+      }
+    }),
+  ],
+};
 ```
 
 The Authgear container instance takes `endpoint` and `clientID` as parameters. They can be obtained from the application page created in [#setup-application-in-authgear](angular.md#setup-application-in-authgear "mention").
 
-It is recommend to render the app after `configure()` resolves. So by the time the app is rendered, Authgear is ready to use.
+Because the initializer is awaited, by the time any route renders Authgear is ready to use.
 
 {% hint style="info" %}
 Run **`npm start`** now and you should see a page with "Hello World" and no error message in the console if Authgear SDK is configured successfully
@@ -163,11 +186,11 @@ Run **`npm start`** now and you should see a page with "Hello World" and no erro
 
 Since we want to reference the logged in state in anywhere of the app, let's put the state in a **service** with `user.service.ts` in the `/src/app/services/` folder.
 
-In `user.service.ts`, it will have a `isLoggedIn` boolean variable. The `isLoggedIn` boolean variable can be auto updated using the `onSessionStateChange` callback. This callback can be stored in `delegate` which is in the local SDK container.
+In `user.service.ts`, it will have an `isLoggedIn` state. The state is auto updated using the `onSessionStateChange` callback, which is stored in the `delegate` of the local SDK container. We expose the state as an Angular [signal](https://angular.dev/guide/signals) so the UI updates reactively (this also works with zoneless change detection, the default on newer Angular versions).
 
 ```typescript
 // src/app/services/user.service.ts
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import authgear from '@authgear/web';
 
 @Injectable({
@@ -175,7 +198,7 @@ import authgear from '@authgear/web';
 })
 export class UserService {
   // By default the user is not logged in
-  isLoggedIn: boolean = false;
+  readonly isLoggedIn = signal(false);
 
   constructor() {
     // When the sessionState changed, logged in state will also be changed
@@ -184,15 +207,37 @@ export class UserService {
         // sessionState is now up to date
         // value of sessionState can be "NO_SESSION" or "AUTHENTICATED"
         const sessionState = container.sessionState;
-        if (sessionState === 'AUTHENTICATED') {
-          this.isLoggedIn = true;
-        } else {
-          this.isLoggedIn = false;
-        }
+        this.isLoggedIn.set(sessionState === 'AUTHENTICATED');
       },
     };
   }
 }
+```
+
+The `onSessionStateChange` delegate fires while `configure()` runs, so the `UserService` must be instantiated **before** `configure()` — otherwise it would miss the initial state of an already-authenticated user. Update the app initializer in `src/app/app.config.ts` to inject the service first:
+
+```typescript
+// src/app/app.config.ts
+import { inject, provideAppInitializer } from '@angular/core';
+import authgear from '@authgear/web';
+import { UserService } from './services/user.service';
+
+// ...
+
+    provideAppInitializer(async () => {
+      // Instantiate UserService first so its onSessionStateChange delegate is
+      // registered before configure() runs and can observe the initial state.
+      inject(UserService);
+      try {
+        await authgear.configure({
+          endpoint: '<your_app_endpoint>',
+          clientID: '<your_client_id>',
+          sessionType: 'refresh_token',
+        });
+      } catch (e) {
+        console.error(e);
+      }
+    }),
 ```
 
 ## Step 4: Implement the Auth Redirect
@@ -205,7 +250,7 @@ Create the `auth-redirect` component using the following command:
 ng generate component auth-redirect
 ```
 
-We will inject the router and the UserService to get the use of navigation and the `isLoggedIn` state.
+We will inject the router to navigate after the redirect is handled.
 
 Call the Authgear `finishAuthentication()` function in the Auth Redirect component to send a token back to Authgear server in exchange for access token and refresh token. Don't worry about the technical jargons, `finishAuthentication()` will do all the hard work for you and and save the authentication data.
 
@@ -215,18 +260,17 @@ The final `auth-redirect.component.ts` will look like this
 
 ```typescript
 // src/app/auth-redirect/auth-redirect.component.ts
-import { Component, OnInit } from '@angular/core';
-import { UserService } from '../services/user.service';
-import authgear from '@authgear/web';
+import { Component, OnInit, inject } from '@angular/core';
 import { Router } from '@angular/router';
+import authgear from '@authgear/web';
 
 @Component({
   selector: 'app-auth-redirect',
   templateUrl: './auth-redirect.component.html',
-  styleUrls: ['./auth-redirect.component.css'],
+  styleUrl: './auth-redirect.component.css',
 })
 export class AuthRedirectComponent implements OnInit {
-  constructor(private router: Router, private user: UserService) {}
+  private readonly router = inject(Router);
 
   ngOnInit(): void {
     authgear
@@ -239,7 +283,7 @@ export class AuthRedirectComponent implements OnInit {
 }
 ```
 
-## Step 5: Add Routes and Context Provider to the App
+## Step 5: Add Routes to the App
 
 Next, we will add a "Home" page . Create a `home` component using the following command:
 
@@ -247,28 +291,37 @@ Next, we will add a "Home" page . Create a `home` component using the following 
 ng generate component home
 ```
 
-Then import **HomeComponent** and **AuthRedirectComponent** as routes. We can add those routes in the `app-routing.module.ts` file:
+Then import **HomeComponent** and **AuthRedirectComponent** as routes. We can add those routes in the `app.routes.ts` file that was generated with the workspace:
 
-```tsx
-// src/app/app-routing.module.ts
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-import { AuthRedirectComponent } from './auth-redirect/auth-redirect.component';
+```typescript
+// src/app/app.routes.ts
+import { Routes } from '@angular/router';
 import { HomeComponent } from './home/home.component';
+import { AuthRedirectComponent } from './auth-redirect/auth-redirect.component';
 
-const routes: Routes = [
+export const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'auth-redirect', component: AuthRedirectComponent },
 ];
-
-@NgModule({
-  imports: [RouterModule.forRoot(routes)],
-  exports: [RouterModule],
-})
-export class AppRoutingModule {}
 ```
 
-You can apply those routes in `src/app/app.component.html` by replace the lines with the following:
+The router is already provided in `app.config.ts` via `provideRouter(routes)` (added in Step 2). Make sure the root component renders the routed component by importing `RouterOutlet` and using it in the template.
+
+```typescript
+// src/app/app.component.ts
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  imports: [RouterOutlet],
+  templateUrl: './app.component.html',
+  styleUrl: './app.component.css',
+})
+export class AppComponent {}
+```
+
+Replace the lines in `src/app/app.component.html` with the following:
 
 ```html
 <router-outlet></router-outlet>
@@ -279,11 +332,12 @@ The file structure should now look like
 ```
 src
 ├── (...)
+├── main.ts
 └── app
-    ├── app-routing.module.ts
+    ├── app.config.ts
+    ├── app.routes.ts
     ├── app.component.ts
     ├── app.component.html
-    ├── app.module.ts
     ├── (...)
     ├── auth-redirect
     │   ├── auth-redirect.component.ts
@@ -299,29 +353,27 @@ src
 
 ## Step 6: Add a Login button
 
-First we will import the Authgear dependency and inject the UserService in `home.component.ts`. Then add the `startLogin` method which will call `startAuthentication(ConfigureOptions)`. This will redirect the user to the login page.
+First we will import the Authgear dependency and inject the UserService in `home.component.ts`. Then add the `startLogin` method which will call `startAuthentication(options)`. This will redirect the user to the login page.
 
-```tsx
+```typescript
 // src/app/home/home.component.ts
-import { Component, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { UserService } from '../services/user.service';
-import authgear from '@authgear/web';
+import authgear, { PromptOption } from '@authgear/web';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css'],
+  styleUrl: './home.component.css',
 })
-export class HomeComponent implements OnInit {
-  constructor(public user: UserService) {}
-
-  ngOnInit(): void {}
+export class HomeComponent {
+  readonly user = inject(UserService);
 
   startLogin(): void {
     authgear
       .startAuthentication({
         redirectURI: 'http://localhost:4000/auth-redirect',
-        prompt: 'login',
+        prompt: PromptOption.Login,
       })
       .then(
         () => {
@@ -335,6 +387,10 @@ export class HomeComponent implements OnInit {
   }
 }
 ```
+
+{% hint style="info" %}
+`prompt` takes a `PromptOption` enum value (for example `PromptOption.Login`) in `@authgear/web` v5 and above. Importing and using the enum keeps the call type-safe.
+{% endhint %}
 
 Then you can add a button which will trigger the `startLogin` method in `home.component.html`:
 
@@ -355,34 +411,34 @@ In the last step, the user is successfully logged in so let's try to print the u
 
 In `home` component, we will add a simple Loading splash and a greeting message printing the Sub ID. We will add two conditional elements such that they are only shown when user is logged in. We can also change the login button to show only if the user is not logged in.
 
-Make use of `isLoggedIn` from the `UserService` to control the components on the page. Fetch the user info by `fetchInfo()` and access its `sub` property.
+Make use of `isLoggedIn` from the `UserService` to control the components on the page. Fetch the user info by `fetchUserInfo()` and access its `sub` property. We store the loading and greeting state as signals so the template stays reactive.
 
-```tsx
+```typescript
 // src/app/home/home.component.ts
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { UserService } from '../services/user.service';
-import authgear from '@authgear/web';
+import authgear, { PromptOption } from '@authgear/web';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css'],
+  styleUrl: './home.component.css',
 })
 export class HomeComponent implements OnInit {
-  isLoading: boolean = false;
-  greetingMessage: string = '';
+  readonly user = inject(UserService);
 
-  constructor(public user: UserService) {}
+  readonly isLoading = signal(false);
+  readonly greetingMessage = signal('');
 
   async updateGreetingMessage() {
-    this.isLoading = true;
+    this.isLoading.set(true);
     try {
-      if (this.user.isLoggedIn) {
+      if (this.user.isLoggedIn()) {
         const userInfo = await authgear.fetchUserInfo();
-        this.greetingMessage = 'The current User sub: ' + userInfo.sub;
+        this.greetingMessage.set('The current User sub: ' + userInfo.sub);
       }
     } finally {
-      this.isLoading = false;
+      this.isLoading.set(false);
     }
   }
 
@@ -396,7 +452,7 @@ export class HomeComponent implements OnInit {
     authgear
       .startAuthentication({
         redirectURI: 'http://localhost:4000/auth-redirect',
-        prompt: 'login',
+        prompt: PromptOption.Login,
       })
       .then(
         () => {
@@ -409,18 +465,23 @@ export class HomeComponent implements OnInit {
       );
   }
 }
-
 ```
 
-In the `home.component.html`:
+In the `home.component.html`, use the new `@if` control flow and read each signal by calling it:
 
 ```html
 <h1>Home Page</h1>
-<span *ngIf="isLoading">Loading</span>
-<span *ngIf="greetingMessage">{{ greetingMessage }}</span>
-<div *ngIf="!user.isLoggedIn">
-  <button type="button" (click)="startLogin()">Login</button>
-</div>
+@if (isLoading()) {
+  <span>Loading</span>
+}
+@if (greetingMessage()) {
+  <span>{{ greetingMessage() }}</span>
+}
+@if (!user.isLoggedIn()) {
+  <div>
+    <button type="button" (click)="startLogin()">Login</button>
+  </div>
+}
 ```
 
 Run the app again, the User ID (sub) of the user should be printed on the Home page.
@@ -432,14 +493,16 @@ Finally, let's add an Logout button when user is logged in.
 In `home.component.html`, we will add a conditional element in the markup:
 
 ```html
-<div *ngIf="user.isLoggedIn">
-  <button type="button" (click)="logout()">Logout</button>
-</div>
+@if (user.isLoggedIn()) {
+  <div>
+    <button type="button" (click)="logout()">Logout</button>
+  </div>
+}
 ```
 
 And add the `logout` method:
 
-```tsx
+```typescript
 logout(): void {
   authgear
     .logout({
@@ -447,7 +510,7 @@ logout(): void {
     })
     .then(
       () => {
-        this.greetingMessage = '';
+        this.greetingMessage.set('');
       },
       (err) => {
         console.error(err);
@@ -467,19 +530,21 @@ Use the `open` function to open the setting page at `<your_app_endpoint>/setting
 In `home.component.html` append a conditional link to the logout button section.
 
 ```html
-<div *ngIf="user.isLoggedIn">
-  <button type="button" (click)="logout()">Logout</button>
-  <br />
-  <a target="_blank" rel="noreferrer" (click)="userSetting($event)" href="#">
-    User Setting
-  </a>
-</div>
+@if (user.isLoggedIn()) {
+  <div>
+    <button type="button" (click)="logout()">Logout</button>
+    <br />
+    <a target="_blank" rel="noreferrer" (click)="userSetting($event)" href="#">
+      User Setting
+    </a>
+  </div>
+}
 ```
 
-And add the `userSetting` method:
+And add the `userSetting` method (note the added `Page` import):
 
-```tsx
-import authgear, { Page } from "@authgear/web";
+```typescript
+import authgear, { Page, PromptOption } from '@authgear/web';
 
 async userSetting(event: MouseEvent) {
   event.preventDefault();
@@ -490,32 +555,32 @@ async userSetting(event: MouseEvent) {
 
 This the resulting `home.component.ts`:
 
-```tsx
+```typescript
 // src/app/home/home.component.ts
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { UserService } from '../services/user.service';
-import authgear, { Page } from '@authgear/web';
+import authgear, { Page, PromptOption } from '@authgear/web';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css'],
+  styleUrl: './home.component.css',
 })
 export class HomeComponent implements OnInit {
-  isLoading: boolean = false;
-  greetingMessage: string = '';
+  readonly user = inject(UserService);
 
-  constructor(public user: UserService) {}
+  readonly isLoading = signal(false);
+  readonly greetingMessage = signal('');
 
   async updateGreetingMessage() {
-    this.isLoading = true;
+    this.isLoading.set(true);
     try {
-      if (this.user.isLoggedIn) {
+      if (this.user.isLoggedIn()) {
         const userInfo = await authgear.fetchUserInfo();
-        this.greetingMessage = 'The current User sub: ' + userInfo.sub;
+        this.greetingMessage.set('The current User sub: ' + userInfo.sub);
       }
     } finally {
-      this.isLoading = false;
+      this.isLoading.set(false);
     }
   }
 
@@ -529,7 +594,7 @@ export class HomeComponent implements OnInit {
     authgear
       .startAuthentication({
         redirectURI: 'http://localhost:4000/auth-redirect',
-        prompt: 'login',
+        prompt: PromptOption.Login,
       })
       .then(
         () => {
@@ -549,7 +614,7 @@ export class HomeComponent implements OnInit {
       })
       .then(
         () => {
-          this.greetingMessage = '';
+          this.greetingMessage.set('');
         },
         (err) => {
           console.error(err);
@@ -569,18 +634,26 @@ This is the resulting home.component.html:
 
 ```html
 <h1>Home Page</h1>
-<span *ngIf="isLoading">Loading</span>
-<span *ngIf="greetingMessage">{{ greetingMessage }}</span>
-<div *ngIf="!user.isLoggedIn">
-  <button type="button" (click)="startLogin()">Login</button>
-</div>
-<div *ngIf="user.isLoggedIn">
-  <button type="button" (click)="logout()">Logout</button>
-  <br />
-  <a target="_blank" rel="noreferrer" (click)="userSetting($event)" href="#">
-    User Setting
-  </a>
-</div>
+@if (isLoading()) {
+  <span>Loading</span>
+}
+@if (greetingMessage()) {
+  <span>{{ greetingMessage() }}</span>
+}
+@if (!user.isLoggedIn()) {
+  <div>
+    <button type="button" (click)="startLogin()">Login</button>
+  </div>
+}
+@if (user.isLoggedIn()) {
+  <div>
+    <button type="button" (click)="logout()">Logout</button>
+    <br />
+    <a target="_blank" rel="noreferrer" (click)="userSetting($event)" href="#">
+      User Setting
+    </a>
+  </div>
+}
 ```
 
 ![Show the User ID, a link to User Settings and a logout button after login](../../.gitbook/assets/spa-react-sample-screenshot.png)


### PR DESCRIPTION
## What & why

The Angular single-page-app quickstart (`get-started/single-page-app/angular.md`) is out of date and no longer works if followed with current tooling:

- It instructs readers to edit `app.module.ts` / `app-routing.module.ts`, but the Angular CLI (17+) scaffolds **standalone** apps and generates neither file.
- `prompt: 'login'` no longer compiles with `@authgear/web` v5, which types the option as the `PromptOption` enum.
- `configure()` is called unawaited in `AppComponent.ngOnInit`, so it races `finishAuthentication()` on the redirect page and `fetchUserInfo()` on home. The SDK requires `configure()` to finish before any other call, so the redirect flow can land back on the home page still showing **Login**. (The doc already advised "render the app after `configure()` resolves" but the code didn't.)
- With zoneless change detection (the default on newer Angular), mutating the plain `isLoggedIn` boolean from the SDK delegate wouldn't update the UI.

This brings the tutorial in line with the sample project [`authgear/authgear-example-angular`](https://github.com/authgear/authgear-example-angular), which was upgraded to Angular 22 and verified end-to-end (login → redirect → home shows user info + Logout).

## Changes

- **Configure at bootstrap:** move `authgear.configure()` into `app.config.ts` via `provideAppInitializer`, awaited before render. Instantiate `UserService` first so its `onSessionStateChange` delegate observes the initial session state (fixes the "already logged in on load" case too).
- **Standalone components:** `app.routes.ts` + `provideRouter`, `RouterOutlet` import, `inject()` instead of constructor injection; drop the NgModule files.
- **Signals + `@if`:** session/loading/greeting state as signals so the UI updates under zoneless change detection.
- **SDK v5:** `prompt: PromptOption.Login`.
- Minor: `fetchInfo()` typo → `fetchUserInfo()`, refresh `angular.io` links to `angular.dev`, and a note about the CLI's new file-naming (no `.component`/`.service` suffix).

## Notes

- Targets Angular 17+; added an intro hint stating this and pointing older `NgModule` users to adapt.
- Kept the tutorial's structure, step numbering, GitBook hints, and images unchanged.
