### PR TITLE
Clarify useEffect double-fire note applies to React 18 and later

### DIFF
--- a/get-started/single-page-app/react.md
+++ b/get-started/single-page-app/react.md
@@ -248,7 +248,7 @@ export default AuthRedirect;
 ```
 
 {% hint style="info" %}
-Since in React 18, useEffect will be fired twice in development mode, we need to implement a [cleanup function](https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development) to stop it from firing twice. We will use an `useRef` Hook to stop the user token from being sent twice to the Authgear Endpoint.
+Since in React 18 and later, useEffect will be fired twice in development mode, we need to implement a [cleanup function](https://beta.reactjs.org/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development) to stop it from firing twice. We will use an `useRef` Hook to stop the user token from being sent twice to the Authgear Endpoint.
 
 Without a cleanup function, an`useEffect`Hook will be fired twice and hence `finishAuthentication()` will send the token back to Authgear Endpoint for two times, which the second one will result in "Invalid Token" error since the token can only be used once.
 {% endhint %}


### PR DESCRIPTION
## What

Update the React SPA getting-started guide's `AuthRedirect` note so it reads "React 18 **and later**" instead of "React 18".

## Why

Following the guide, `npm create vite@latest -- --template react-ts` now scaffolds **React 19**. React 19's StrictMode still double-invokes `useEffect` in development, exactly as React 18 did, so the `useRef` guard that prevents `finishAuthentication()` from sending the token twice (and hitting an "Invalid Token" error) is still required. The current "React 18" wording reads as if the caveat is version-specific/outdated; "React 18 and later" keeps the rationale correct for current React versions.

No code or API changes — the sample code is unchanged and works as-is with the current `@authgear/web` SDK.

## Change

One line in `get-started/single-page-app/react.md` (+1/-1).