### PR TITLE
Fix `fetchInfo()` typo in SPA quickstarts

### DIFF
--- a/get-started/single-page-app/react.md
+++ b/get-started/single-page-app/react.md
@@ -347,7 +347,7 @@ In the last step, the user is successfully logged in, so let's try to print the 
 
 In `Home.tsx`, we will add a simple loading splash and a greeting message printing the Sub ID. We will add two conditional elements such that they are only shown when user is logged in. We can also change the login button to show only if the user is not logged in.
 
-Make use of `isLoggedIn` from the `UserContext` to control the components on the page. Fetch the user info by `fetchInfo()` and access its `sub` property.
+Make use of `isLoggedIn` from the `UserContext` to control the components on the page. Fetch the user info by `fetchUserInfo()` and access its `sub` property.
 
 ```tsx
 // src/Home.tsx  

--- a/get-started/single-page-app/vue.md
+++ b/get-started/single-page-app/vue.md
@@ -417,7 +417,7 @@ In the last step, the user is successfully logged in so let's try to print the u
 
 In `Home.vue`, we will add a simple Loading splash and a greeting message printing the Sub ID. We will add two conditional elements such that they are only shown when user is logged in. We can also change the login button to show only if the user is not logged in.
 
-Make use of `isLoggedIn` from the `UserProvider` to control the components on the page. Fetch the user info by `fetchInfo()` and access its `sub` property.
+Make use of `isLoggedIn` from the `UserProvider` to control the components on the page. Fetch the user info by `fetchUserInfo()` and access its `sub` property.
 
 The Login button can be also rendered conditionally which only visible if the user is not logged in.
 


### PR DESCRIPTION
## Summary

The **Vue** and **React** single-page-app quickstarts describe fetching user info with `fetchInfo()` in the prose, but the correct `@authgear/web` SDK method is `fetchUserInfo()` — which is what the accompanying code samples on the same pages actually call. This fixes the inconsistency.

## Changes

- `get-started/single-page-app/vue.md` — `fetchInfo()` → `fetchUserInfo()`
- `get-started/single-page-app/react.md` — `fetchInfo()` → `fetchUserInfo()`

## Verification

Confirmed against `@authgear/web` v5.1.0 that the method is `fetchUserInfo()`, and that each page's own code blocks already use `fetchUserInfo()` — only the prose was wrong.