### PR TITLE
docs(ionic): use capacitor.config.json (TypeScript 7)

### DIFF
--- a/get-started/native-mobile-app/ionic.md
+++ b/get-started/native-mobile-app/ionic.md
@@ -90,13 +90,17 @@ ionic start authgear-ionic-example --type=react --capacitor
 
 After running the above command, follow the wizard to create a new **blank project**.
 
-Next, open your new project in a code editor and update for `appId` in **capacitor.config.ts** to the following value:
+Next, open your new project in a code editor and configure the `appId`. Because the current Capacitor CLI cannot compile a TypeScript config file under **TypeScript 7** (the current release), replace the generated `capacitor.config.ts` with a **`capacitor.config.json`** file containing:
 
-```typescript
-appId: 'com.authgear.example.capacitor',
+```json
+{
+  "appId": "com.authgear.example.capacitor",
+  "appName": "authgear-ionic-example",
+  "webDir": "dist"
+}
 ```
 
-This new value for `appId` is the same value we used in the authorized redirect URI earlier.
+This value for `appId` is the same value we used in the authorized redirect URI earlier.
 
 {% hint style="info" %}
 **Note:** It is important that you update the value for `appId` before you create the Android and iOS projects for your Ionic application. Doing this will enable Capacitor to create your Android and iOS project with the value for appId as the package name and app ID.


### PR DESCRIPTION
## What

Updates the Ionic getting-started guide (Step 1) to configure `appId` in **`capacitor.config.json`** instead of `capacitor.config.ts`.

## Why

TypeScript 7 is the current release, and the Capacitor CLI cannot compile a TypeScript config file under it — `npx cap sync` / `cap add` fails while parsing `capacitor.config.ts`:

```
[error] Parsing capacitor.config.ts failed.
TypeError: Cannot read properties of undefined (reading 'CommonJS')
```

Using `capacitor.config.json` avoids the TypeScript-transpile step entirely. The example repo [`authgear/authgear-example-ionic`](https://github.com/authgear/authgear-example-ionic) now ships a `capacitor.config.json` after its dependency update, so the guide now matches it.

## Notes

- Assumes the current toolchain (TypeScript 7+); the guide now instructs replacing the generated `capacitor.config.ts` with `capacitor.config.json`.
- Scoped to this config-file change. (The guide's hardcoded `CLIENT_ID`/`ENDPOINT` constants differ from the repo's `.env`-based setup, but that predates this change and is left out of scope.)