### PR TITLE
Revert Ionic guide to capacitor.config.ts (undo #43)

### DIFF
--- a/get-started/native-mobile-app/ionic.md
+++ b/get-started/native-mobile-app/ionic.md
@@ -90,17 +90,13 @@ ionic start authgear-ionic-example --type=react --capacitor
 
 After running the above command, follow the wizard to create a new **blank project**.
 
-Next, open your new project in a code editor and configure the `appId`. Because the current Capacitor CLI cannot compile a TypeScript config file under **TypeScript 7** (the current release), replace the generated `capacitor.config.ts` with a **`capacitor.config.json`** file containing:
+Next, open your new project in a code editor and update for `appId` in **capacitor.config.ts** to the following value:
 
-```json
-{
-  "appId": "com.authgear.example.capacitor",
-  "appName": "authgear-ionic-example",
-  "webDir": "dist"
-}
+```typescript
+appId: 'com.authgear.example.capacitor',
 ```
 
-This value for `appId` is the same value we used in the authorized redirect URI earlier.
+This new value for `appId` is the same value we used in the authorized redirect URI earlier.
 
 {% hint style="info" %}
 **Note:** It is important that you update the value for `appId` before you create the Android and iOS projects for your Ionic application. Doing this will enable Capacitor to create your Android and iOS project with the value for appId as the package name and app ID.


### PR DESCRIPTION
## What

Reverts #43 — restores the original `capacitor.config.ts` instruction in the Ionic getting-started guide (Step 1).

## Why

#43 changed the guide to use `capacitor.config.json` on the premise that projects are on TypeScript 7. But a reader following this guide from scratch won't be:

- `ionic start --type=react --capacitor` scaffolds a project that pins TypeScript on the **5.x** line (`typescript@^5.x`), so `npm install` never resolves TypeScript 7.
- On TypeScript 5.x, the generated `capacitor.config.ts` compiles fine — no need for the JSON workaround.

The TypeScript 7 / `capacitor.config.json` issue only arises when a project is **explicitly upgraded** to TS 7 (as the example repo was, via a dependency bump) — which is not the from-scratch path this guide documents. Keeping the original `.ts` instruction is correct for tutorial followers and simpler to follow.