### PR TITLE
docs(custom-ui): Single Sign-On Continuation with Custom UI

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -129,6 +129,7 @@
   * [Add Custom Login/Signup UI to Native Apps](customization/ui-customization/custom-ui/add-custom-login-signup-ui-to-native-apps.md)
   * [Manually Link OAuth Provider using Account Management API](customization/ui-customization/custom-ui/manually-link-oauth-provider-using-account-management-api.md)
   * [Implement a custom account recovery UI using Authentication Flow API](customization/ui-customization/custom-ui/implement-a-custom-account-recovery-ui-using-authentication-flow-api.md)
+  * [Single Sign-On Continuation with Custom UI](customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md)
 * [Custom Domain](customization/custom-domain.md)
 * [Custom Email and SMS Templates](customization/ui-customization/custom-email-and-sms-templates.md)
 * [Custom Email Provider](customization/custom-providers/custom-email-provider.md)

--- a/customization/ui-customization/custom-ui/README.md
+++ b/customization/ui-customization/custom-ui/README.md
@@ -23,3 +23,7 @@ You can build your own custom UI powered by the new Authentication Flow API. Her
 {% content-ref url="add-custom-login-signup-ui-to-native-apps.md" %}
 [add-custom-login-signup-ui-to-native-apps.md](add-custom-login-signup-ui-to-native-apps.md)
 {% endcontent-ref %}
+
+{% content-ref url="single-sign-on-continuation-with-custom-ui.md" %}
+[single-sign-on-continuation-with-custom-ui.md](single-sign-on-continuation-with-custom-ui.md)
+{% endcontent-ref %}

--- a/customization/ui-customization/custom-ui/authentication-flow-api.md
+++ b/customization/ui-customization/custom-ui/authentication-flow-api.md
@@ -73,7 +73,7 @@ The following is a sample of the response you would get from the Authentication 
 The above response means you've successfully started a new login flow using the API.
 
 {% hint style="info" %}
-If the browser already has an active Authgear session and your flow config enables it, the `options` array can also include a `select_account` entry, letting the user continue as their existing account without re-entering credentials. See [Single Sign-On Continuation with Custom UI](single-sign-on-continuation-with-custom-ui.md).
+If the browser already has an active Authgear session and your flow config enables it, the `options` array can also include a `select_account` entry. This lets the user continue as their existing account without re-entering credentials. See [Single Sign-On Continuation with Custom UI](single-sign-on-continuation-with-custom-ui.md).
 {% endhint %}
 
 To continue and finish the authentication flow, you can send the value for `state_token` from the above response in your next HTTP request to the `api/v1/authentication_flows/states/input` endpoint like the example shown below:
@@ -154,7 +154,7 @@ When you use the authentication flow API to power your custom UI, the authentica
 
 If you have Authentication Flow API enabled and a Custom UI URI set for your Authgear App, the authorization server will redirect your users to the custom UI as shown in **step 2** above.
 
-The redirect includes query parameters such as `client_id`, `redirect_uri`, and `x_ref` that your custom UI should forward back to the API via `url_query`. If the authorization request carries `login_hint` or `id_token_hint`, those are forwarded on the redirect too, so your custom UI can read them — for example to pre-fill an identifier field or to decide whether to offer [Single Sign-On Continuation](single-sign-on-continuation-with-custom-ui.md).
+The redirect includes query parameters such as `client_id`, `redirect_uri`, and `x_ref` that your custom UI should forward back to the API via `url_query`. If the authorization request carries `login_hint` or `id_token_hint`, those are forwarded on the redirect too. Your custom UI can read them to pre-fill an identifier field, or to decide whether to offer [Single Sign-On Continuation](single-sign-on-continuation-with-custom-ui.md).
 
 #### Step 3: Make HTTP Requests to Authentication Flow API Endpoints
 

--- a/customization/ui-customization/custom-ui/authentication-flow-api.md
+++ b/customization/ui-customization/custom-ui/authentication-flow-api.md
@@ -72,6 +72,10 @@ The following is a sample of the response you would get from the Authentication 
 
 The above response means you've successfully started a new login flow using the API.
 
+{% hint style="info" %}
+If the browser already has an active Authgear session and your flow config enables it, the `options` array can also include a `select_account` entry, letting the user continue as their existing account without re-entering credentials. See [Single Sign-On Continuation with Custom UI](single-sign-on-continuation-with-custom-ui.md).
+{% endhint %}
+
 To continue and finish the authentication flow, you can send the value for `state_token` from the above response in your next HTTP request to the `api/v1/authentication_flows/states/input` endpoint like the example shown below:
 
 **Endpoint:** `{your-authgear-project-domain}/api/v1/authentication_flows/states/input`
@@ -149,6 +153,8 @@ When you use the authentication flow API to power your custom UI, the authentica
 #### Step 2: Redirect to Custom UI
 
 If you have Authentication Flow API enabled and a Custom UI URI set for your Authgear App, the authorization server will redirect your users to the custom UI as shown in **step 2** above.
+
+The redirect includes query parameters such as `client_id`, `redirect_uri`, and `x_ref` that your custom UI should forward back to the API via `url_query`. If the authorization request carries `login_hint` or `id_token_hint`, those are forwarded on the redirect too, so your custom UI can read them — for example to pre-fill an identifier field or to decide whether to offer [Single Sign-On Continuation](single-sign-on-continuation-with-custom-ui.md).
 
 #### Step 3: Make HTTP Requests to Authentication Flow API Endpoints
 

--- a/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
+++ b/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
@@ -14,7 +14,7 @@ If you are new to building a Custom UI, read the [Authentication Flow API](authe
 
 ## Use cases
 
-**Single sign-on across apps in the same project.** Two applications, App A and App B, are OAuth clients of the same Authgear project, and each has its own Custom UI. A user signs in to App A, then opens App B for the first time in the same browser. Because the Authgear session cookie is shared, App B's Custom UI can offer to continue as the same account. The user clicks once instead of typing their credentials again.
+**Single sign-on across apps in the same project.** Two applications, App A and App B, are OAuth clients of the same Authgear project and share the same Custom UI. A user signs in to App A, then opens App B for the first time in the same browser. Because the Authgear session cookie is shared, the Custom UI can offer to continue as the same account. The user clicks once instead of typing their credentials again.
 
 **A single "Continue" entry point.** Your Custom UI uses one combined screen (a `signup_login` flow) instead of separate sign-in and sign-up pages. When a session already exists, the screen shows "Continue as user@example.com" alongside the usual email and social login options. To decline, the user picks another option instead, and can even register a second account that way.
 
@@ -26,15 +26,15 @@ If you are new to building a Custom UI, read the [Authentication Flow API](authe
 
 ```mermaid
 flowchart TD
+    appa["App A"] --> ui
+    appb["App B"] --> ui
     subgraph samesite ["example.com — same registrable domain"]
+        ui["Shared Custom UI<br/>ui.example.com"]
         authgear["Authgear<br/>auth.example.com"]
-        uia["Custom UI of App A<br/>ui-a.example.com"]
-        uib["Custom UI of App B<br/>ui-b.example.com"]
     end
     other["Custom UI on an unrelated domain<br/>ui.other-domain.io"]
 
-    uia -- "session cookie sent,<br/>select_account offered" --> authgear
-    uib -- "session cookie sent,<br/>select_account offered" --> authgear
+    ui -- "session cookie sent,<br/>select_account offered" --> authgear
     other -. "cookie never sent,<br/>option never appears" .-> authgear
 ```
 

--- a/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
+++ b/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
@@ -1,0 +1,264 @@
+---
+description: >-
+  Let users who already have an active Authgear session continue as their
+  existing account in your Custom UI, without re-entering their credentials.
+---
+
+# Single Sign-On Continuation with Custom UI
+
+When an end-user already has an active Authgear session in their browser, your Custom UI can show a **"Continue as user@example.com"** option instead of asking them to enter their credentials again. This is powered by `select_account`, an identification option you can add to the `identify` step of `login` and `signup_login` flows.
+
+`select_account` works through the same Authentication Flow API endpoints your Custom UI already calls — there is no new endpoint and no new token. When the browser has an eligible session, the `identify` step's response includes an extra option describing the account; when there is none, the response looks exactly as it did before, so a Custom UI that does not recognize the option keeps working unchanged.
+
+If you are new to building a Custom UI, read the [Authentication Flow API](authentication-flow-api.md) overview first.
+
+## Use cases
+
+**Single sign-on across apps in the same project.** Two applications, App A and App B, are OAuth clients of the same Authgear project, and each has its own Custom UI. A user signs in to App A, then opens App B for the first time in the same browser. Because the Authgear session cookie is shared, App B's Custom UI can offer to continue as the same account — the user clicks once instead of typing their credentials again.
+
+**A single "Continue" entry point.** Your Custom UI uses one combined screen (a `signup_login` flow) instead of separate sign-in and sign-up pages. When a session already exists, the screen shows "Continue as user@example.com" alongside the usual email and social login options. Declining is nothing special: the user simply picks another option, and can even register a second account that way.
+
+## Prerequisites
+
+* **Your Custom UI must be same-site with your Authgear endpoint.** The browser only sends the Authgear session cookie to the Authentication Flow API when your Custom UI and your Authgear endpoint share a registrable domain — for example `auth.example.com` and `ui.example.com`. In practice this means setting up a [Custom Domain](../../custom-domain.md) for your project. A Custom UI hosted on an unrelated domain never sees the `select_account` option.
+* **Custom UI URI configured.** Your OAuth client must have its **Custom UI URI** set in the Authgear Portal (**Applications** > your application > **Custom UI**). Authgear allows cross-origin requests with credentials from origins registered as a Custom UI URI, so no extra CORS setup is needed on your side.
+* **Send the session cookie from the browser.** Calls to the Authentication Flow API made with `fetch()` must use `credentials: 'include'`, otherwise the session cookie is not sent and the option never appears.
+
+{% hint style="info" %}
+If your Custom UI has separate sign-in and sign-up screens, its **first** call to create a flow must be of type `login` or `signup_login` — never `signup` directly. `select_account` only exists in those two flow types, so starting with `signup` means you never find out that a session exists. Create a separate `signup` flow afterward only if the user has no eligible session (or declines it) and wants a new account.
+{% endhint %}
+
+## Step 1: Add select\_account to your flow config
+
+In the Authgear Portal, go to **Advanced** > **Edit Config** and add `select_account` to the `identify` step of your login flow, under the `authentication_flow` section:
+
+{% code lineNumbers="true" %}
+```yaml
+authentication_flow:
+  login_flows:
+  - name: default
+    steps:
+    - type: identify
+      one_of:
+      - identification: select_account
+      - identification: email
+        steps:
+        - type: authenticate
+          one_of:
+          - authentication: primary_password
+```
+{% endcode %}
+
+The `select_account` entry above has no nested `steps`, so choosing it completes the login immediately. To ask for something extra first (for example a 2FA code), give the entry its own nested `authenticate` step — see [Require 2FA on continuation](#require-2fa-on-continuation) below.
+
+## Step 2: Detect the option in your Custom UI
+
+Create the flow as usual, forwarding the query parameters Authgear passed to your Custom UI URI (in particular `client_id` and `x_ref`) via `url_query`:
+
+```javascript
+const response = await fetch("https://auth.example.com/api/v1/authentication_flows", {
+  method: "POST",
+  credentials: "include", // required: sends the Authgear session cookie
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    type: "login",
+    name: "default",
+    url_query: window.location.search.substring(1),
+  }),
+});
+```
+
+When the browser has an eligible session, the `identify` step's `options` include a `select_account` entry with the account's display name and user ID:
+
+```json
+{
+    "result": {
+        "state_token": "authflowstate_VGHZ8SBCKGZK2KW84TCAKWGM8QZH0B69",
+        "type": "login",
+        "name": "default",
+        "action": {
+            "type": "identify",
+            "data": {
+                "type": "identification_data",
+                "options": [
+                    {
+                        "identification": "select_account",
+                        "display_name": "user@example.com",
+                        "user_id": "user_01J8ZC0M2N3P4Q5R6S7T8V9W0X"
+                    },
+                    {
+                        "identification": "email"
+                    }
+                ]
+            }
+        }
+    }
+}
+```
+
+Use `display_name` to render the "Continue as user@example.com" button. Unlike `masked_display_name` elsewhere in this API, it is returned unmasked: it identifies the account already bound to the caller's own session cookie, so there is nothing to hide.
+
+When there is no eligible session, the `select_account` entry is simply absent and the response is identical to what it was before this feature.
+
+## Step 3: Submit the selection
+
+When the user clicks "Continue as...", submit the option by its `index` — its position in the `options` array:
+
+```json
+{
+    "state_token": "authflowstate_VGHZ8SBCKGZK2KW84TCAKWGM8QZH0B69",
+    "input": {
+        "identification": "select_account",
+        "index": 0
+    }
+}
+```
+
+With the minimal config from Step 1, the flow finishes immediately:
+
+```json
+{
+    "result": {
+        "state_token": "authflowstate_ABCJVB0IJKLQ2S1K2G34RX56R1C1E789",
+        "type": "login",
+        "name": "default",
+        "action": {
+            "type": "finished",
+            "data": {
+                "finish_redirect_uri": "https://auth.example.com/oauth2/consent?..."
+            }
+        }
+    }
+}
+```
+
+Redirect the browser to `finish_redirect_uri` with a top-level navigation (not a `fetch()` call), exactly as for any other completed flow. The user never re-entered credentials — they only clicked once.
+
+{% hint style="info" %}
+`user_id` is informational and read-only. The input only ever carries `index`; the server re-resolves the account from its own session cookie at submission time, so a forged or stale `user_id` can never be used to select a different account.
+{% endhint %}
+
+## Step 4: Handle the user declining
+
+There is no dedicated "decline" input. If the user wants to sign in as someone else, submit any other option's input instead, for example:
+
+```json
+{
+    "state_token": "authflowstate_VGHZ8SBCKGZK2KW84TCAKWGM8QZH0B69",
+    "input": {
+        "identification": "email",
+        "login_id": "another-user@example.com"
+    }
+}
+```
+
+The flow then proceeds exactly as a normal login.
+
+## Using select\_account in signup\_login flows
+
+In a `signup_login` flow, `select_account` declares a `login_flow` only — it can only ever continue an existing login, never a signup. Choosing it switches into the named login flow, so **that login flow must itself declare a `select_account` entry** for the switch to land anywhere:
+
+{% code lineNumbers="true" %}
+```yaml
+authentication_flow:
+  signup_login_flows:
+  - name: default
+    steps:
+    - type: identify
+      one_of:
+      - identification: select_account
+        login_flow: default_login
+      - identification: email
+        signup_flow: default_signup
+        login_flow: default_login
+
+  login_flows:
+  - name: default_login
+    steps:
+    - type: identify
+      one_of:
+      - identification: select_account
+      - identification: email
+        steps:
+        - type: authenticate
+          one_of:
+          - authentication: primary_password
+```
+{% endcode %}
+
+Any steps configured after `identify` in the target login flow (for example `terminate_other_sessions`) still run — continuing via `select_account` does not skip them.
+
+## Require 2FA on continuation
+
+To ask for a fresh second factor specifically when continuing with an existing session — without adding that step to normal logins — give the `select_account` entry its own nested `authenticate` step:
+
+{% code lineNumbers="true" %}
+```yaml
+      one_of:
+      - identification: select_account
+        steps:
+        - type: authenticate
+          one_of:
+          - authentication: secondary_totp
+```
+{% endcode %}
+
+Submitting `select_account` then returns an `authenticate` action instead of finishing:
+
+```json
+{
+    "result": {
+        "state_token": "authflowstate_XYZ3JVB0IJKLQ2S1K2G34RX56R1C1E78",
+        "type": "login",
+        "name": "default",
+        "action": {
+            "type": "authenticate",
+            "authentication": "secondary_totp",
+            "data": {
+                "type": "authentication_data",
+                "options": [
+                    { "authentication": "secondary_totp" }
+                ]
+            }
+        }
+    }
+}
+```
+
+Submit the TOTP code as usual to complete the flow.
+
+## Enforcing login\_hint or id\_token\_hint
+
+If your application passes `login_hint` or `id_token_hint` in the authorization request, Authgear forwards both parameters on the redirect to your Custom UI URI, alongside `client_id` and `x_ref`.
+
+The Authentication Flow API deliberately does **not** filter the `select_account` option by these hints — the option is offered whenever an eligible session exists. If you want "only offer continuation when it matches the hint" behavior, implement it in your Custom UI: resolve the hint yourself, compare it against the option's `user_id`, and hide the option on a mismatch, falling back to whatever your UI does when there is no eligible session. A Custom UI that does not care about hints can ignore `user_id` entirely.
+
+## Error handling
+
+If the session changes between the option being shown and the input being submitted — for example the user logged out or switched accounts in another tab — the API responds with:
+
+```json
+{
+    "error": {
+        "name": "Unauthorized",
+        "reason": "SelectAccountSessionChanged",
+        "message": "session no longer matches the selected account",
+        "code": 401
+    }
+}
+```
+
+Handle this by restarting the flow: create a new authentication flow and render whatever options the fresh response contains.
+
+## When the option will not appear
+
+The `select_account` option is omitted, and the response looks exactly as it did before this feature, when any of the following holds:
+
+* There is no active session, or the session cookie was not sent (missing `credentials: 'include'`, or the Custom UI is not same-site with Authgear).
+* The flow config's `identify` step does not list `select_account`.
+* The authorization request carries `prompt=login`, or its `max_age` has expired (which Authgear treats as `prompt=login`).
+* The session was established with SSO disabled — for example an SDK configured with `isSSOEnabled: false`, which suppresses the shared session cookie (see [SSO with mobile apps / websites](../../../authentication-and-access/single-sign-on/sso-with-mobile-app-web-spa.md)).
+
+{% hint style="warning" %}
+`prompt=select_account` in the authorization request is unrelated to this feature and has no effect, despite sharing the name.
+{% endhint %}

--- a/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
+++ b/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
@@ -8,20 +8,20 @@ description: >-
 
 When an end-user already has an active Authgear session in their browser, your Custom UI can show a **"Continue as user@example.com"** option instead of asking them to enter their credentials again. This is powered by `select_account`, an identification option you can add to the `identify` step of `login` and `signup_login` flows.
 
-`select_account` works through the same Authentication Flow API endpoints your Custom UI already calls — there is no new endpoint and no new token. When the browser has an eligible session, the `identify` step's response includes an extra option describing the account; when there is none, the response looks exactly as it did before, so a Custom UI that does not recognize the option keeps working unchanged.
+`select_account` works through the same Authentication Flow API endpoints your Custom UI already calls. There is no new endpoint and no new token. When the browser has an eligible session, the `identify` step's response includes an extra option describing the account. When there is none, the response is unchanged, so a Custom UI that does not recognize the option keeps working as before.
 
 If you are new to building a Custom UI, read the [Authentication Flow API](authentication-flow-api.md) overview first.
 
 ## Use cases
 
-**Single sign-on across apps in the same project.** Two applications, App A and App B, are OAuth clients of the same Authgear project, and each has its own Custom UI. A user signs in to App A, then opens App B for the first time in the same browser. Because the Authgear session cookie is shared, App B's Custom UI can offer to continue as the same account — the user clicks once instead of typing their credentials again.
+**Single sign-on across apps in the same project.** Two applications, App A and App B, are OAuth clients of the same Authgear project, and each has its own Custom UI. A user signs in to App A, then opens App B for the first time in the same browser. Because the Authgear session cookie is shared, App B's Custom UI can offer to continue as the same account. The user clicks once instead of typing their credentials again.
 
-**A single "Continue" entry point.** Your Custom UI uses one combined screen (a `signup_login` flow) instead of separate sign-in and sign-up pages. When a session already exists, the screen shows "Continue as user@example.com" alongside the usual email and social login options. Declining is nothing special: the user simply picks another option, and can even register a second account that way.
+**A single "Continue" entry point.** Your Custom UI uses one combined screen (a `signup_login` flow) instead of separate sign-in and sign-up pages. When a session already exists, the screen shows "Continue as user@example.com" alongside the usual email and social login options. To decline, the user picks another option instead, and can even register a second account that way.
 
 ## Prerequisites
 
-* **Your Custom UI must be same-site with your Authgear endpoint.** The browser only sends the Authgear session cookie to the Authentication Flow API when your Custom UI and your Authgear endpoint share a registrable domain — for example `auth.example.com` and `ui.example.com`. In practice this means setting up a [Custom Domain](../../custom-domain.md) for your project. A Custom UI hosted on an unrelated domain never sees the `select_account` option.
-* **Custom UI URI configured.** Your OAuth client must have its **Custom UI URI** set in the Authgear Portal (**Applications** > your application > **Custom UI**). Authgear allows cross-origin requests with credentials from origins registered as a Custom UI URI, so no extra CORS setup is needed on your side.
+* **Your Custom UI must be same-site with your Authgear endpoint.** The browser only sends the Authgear session cookie to the Authentication Flow API when your Custom UI and your Authgear endpoint share a registrable domain (the eTLD+1, such as `example.com`): for example `auth.example.com` and `ui.example.com`. In practice this means setting up a [Custom Domain](../../custom-domain.md) for your project. A Custom UI hosted on an unrelated domain never sees the `select_account` option.
+* **Custom UI URI configured.** Your OAuth client must have its **Custom UI URI** set in the Authgear Portal (**Applications** > your application > **Custom UI**). Note that same-site is not the same as same-origin: `ui.example.com` and `auth.example.com` are still cross-origin, so the browser applies CORS to these API calls. Authgear allows cross-origin requests with credentials from origins registered as a Custom UI URI, so no extra CORS setup is needed on your side.
 * **Send the session cookie from the browser.** Calls to the Authentication Flow API made with `fetch()` must use `credentials: 'include'`, otherwise the session cookie is not sent and the option never appears.
 
 ```mermaid
@@ -39,12 +39,12 @@ flowchart TD
 ```
 
 {% hint style="info" %}
-If your Custom UI has separate sign-in and sign-up screens, its **first** call to create a flow must be of type `login` or `signup_login` — never `signup` directly. `select_account` only exists in those two flow types, so starting with `signup` means you never find out that a session exists. Create a separate `signup` flow afterward only if the user has no eligible session (or declines it) and wants a new account.
+If your Custom UI has separate sign-in and sign-up screens, its **first** call to create a flow must be of type `login` or `signup_login`, never `signup` directly. `select_account` only exists in those two flow types, so starting with `signup` means you never find out that a session exists. Create a separate `signup` flow afterward only if the user has no eligible session (or declines it) and wants a new account.
 {% endhint %}
 
 ## How it works
 
-The select-account exchange sits inside the same OAuth flow every Custom UI already follows — the only new parts are the extra option in the `identify` response and the one-click input that completes it:
+The select-account exchange sits inside the same OAuth flow every Custom UI already follows. The only new parts are the extra option in the `identify` response and the one-click input that completes it:
 
 ```mermaid
 sequenceDiagram
@@ -65,7 +65,7 @@ sequenceDiagram
     App->>Authgear: POST /oauth2/token (exchange code for tokens)
 ```
 
-The user never typed a credential — the only interaction was the click on "Continue as user@example.com". When there is no eligible session, the third step's response simply has no `select_account` entry and your UI proceeds as a normal login.
+The user never typed a credential; the only interaction was the click on "Continue as user@example.com". When there is no eligible session, the flow-creation response has no `select_account` entry and your UI proceeds as a normal login.
 
 ## Step 1: Add select\_account to your flow config
 
@@ -88,7 +88,7 @@ authentication_flow:
 ```
 {% endcode %}
 
-The `select_account` entry above has no nested `steps`, so choosing it completes the login immediately. To ask for something extra first (for example a 2FA code), give the entry its own nested `authenticate` step — see [Require 2FA on continuation](#require-2fa-on-continuation) below.
+The `select_account` entry above has no nested `steps`, so choosing it completes the login immediately. To ask for something extra first (for example a 2FA code), give the entry its own nested `authenticate` step. See [Require 2FA on continuation](#require-2fa-on-continuation) below.
 
 ## Step 2: Detect the option in your Custom UI
 
@@ -135,13 +135,13 @@ When the browser has an eligible session, the `identify` step's `options` includ
 }
 ```
 
-Use `display_name` to render the "Continue as user@example.com" button. Unlike `masked_display_name` elsewhere in this API, it is returned unmasked: it identifies the account already bound to the caller's own session cookie, so there is nothing to hide.
+Use `display_name` to render the "Continue as user@example.com" button. Unlike `masked_display_name` elsewhere in this API, it is returned unmasked because it identifies the account already bound to the caller's own session cookie.
 
-When there is no eligible session, the `select_account` entry is simply absent and the response is identical to what it was before this feature.
+When there is no eligible session, the `select_account` entry is absent and the rest of the response is unchanged.
 
 ## Step 3: Submit the selection
 
-When the user clicks "Continue as...", submit the option by its `index` — its position in the `options` array:
+When the user clicks "Continue as...", submit the option by its `index`, its position in the `options` array:
 
 ```json
 {
@@ -171,7 +171,7 @@ With the minimal config from Step 1, the flow finishes immediately:
 }
 ```
 
-Redirect the browser to `finish_redirect_uri` with a top-level navigation (not a `fetch()` call), exactly as for any other completed flow. The user never re-entered credentials — they only clicked once.
+Redirect the browser to `finish_redirect_uri` with a top-level navigation (not a `fetch()` call), exactly as for any other completed flow.
 
 {% hint style="info" %}
 `user_id` is informational and read-only. The input only ever carries `index`; the server re-resolves the account from its own session cookie at submission time, so a forged or stale `user_id` can never be used to select a different account.
@@ -195,7 +195,7 @@ The flow then proceeds exactly as a normal login.
 
 ## Using select\_account in signup\_login flows
 
-In a `signup_login` flow, `select_account` declares a `login_flow` only — it can only ever continue an existing login, never a signup. Choosing it switches into the named login flow, so **that login flow must itself declare a `select_account` entry** for the switch to land anywhere:
+In a `signup_login` flow, `select_account` declares a `login_flow` only; it can only ever continue an existing login, never a signup. Choosing it switches into the named login flow and replays the same `identify` input there, so **that login flow must itself declare a `select_account` entry**. If it does not, the replayed input matches no option in the target flow and the submission fails instead of completing the login:
 
 {% code lineNumbers="true" %}
 ```yaml
@@ -225,11 +225,11 @@ authentication_flow:
 ```
 {% endcode %}
 
-Any steps configured after `identify` in the target login flow (for example `terminate_other_sessions`) still run — continuing via `select_account` does not skip them.
+Any steps configured after `identify` in the target login flow (for example `terminate_other_sessions`) still run; continuing via `select_account` does not skip them.
 
 ## Require 2FA on continuation
 
-To ask for a fresh second factor specifically when continuing with an existing session — without adding that step to normal logins — give the `select_account` entry its own nested `authenticate` step:
+To ask for a fresh second factor when continuing with an existing session, without adding that step to normal logins, give the `select_account` entry its own nested `authenticate` step:
 
 {% code lineNumbers="true" %}
 ```yaml
@@ -270,11 +270,11 @@ Submit the TOTP code as usual to complete the flow.
 
 If your application passes `login_hint` or `id_token_hint` in the authorization request, Authgear forwards both parameters on the redirect to your Custom UI URI, alongside `client_id` and `x_ref`.
 
-The Authentication Flow API deliberately does **not** filter the `select_account` option by these hints — the option is offered whenever an eligible session exists. If you want "only offer continuation when it matches the hint" behavior, implement it in your Custom UI: resolve the hint yourself, compare it against the option's `user_id`, and hide the option on a mismatch, falling back to whatever your UI does when there is no eligible session. A Custom UI that does not care about hints can ignore `user_id` entirely.
+The Authentication Flow API deliberately does **not** filter the `select_account` option by these hints; the option is offered whenever an eligible session exists. If you want to offer continuation only when it matches the hint, implement the check in your Custom UI: resolve the hint yourself, compare it against the option's `user_id`, and hide the option on a mismatch, falling back to whatever your UI does when there is no eligible session. For `id_token_hint`, that means decoding the ID token and comparing its `sub` claim against the option's `user_id`. A Custom UI that does not care about hints can ignore `user_id` entirely.
 
 ## Error handling
 
-If the session changes between the option being shown and the input being submitted — for example the user logged out or switched accounts in another tab — the API responds with:
+If the session changes between the option being shown and the input being submitted (for example, the user logged out or switched accounts in another tab), the API responds with:
 
 ```json
 {
@@ -291,7 +291,7 @@ Handle this by restarting the flow: create a new authentication flow and render 
 
 ## When the option will not appear
 
-The `select_account` option is omitted, and the response looks exactly as it did before this feature, when any of the following holds:
+The `select_account` option is omitted, and the response is the same as if the feature were not configured, when any of the following holds:
 
 * There is no active session, or the session cookie was not sent (missing `credentials: 'include'`, or the Custom UI is not same-site with Authgear).
 * The flow config's `identify` step does not list `select_account`.

--- a/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
+++ b/customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md
@@ -24,9 +24,48 @@ If you are new to building a Custom UI, read the [Authentication Flow API](authe
 * **Custom UI URI configured.** Your OAuth client must have its **Custom UI URI** set in the Authgear Portal (**Applications** > your application > **Custom UI**). Authgear allows cross-origin requests with credentials from origins registered as a Custom UI URI, so no extra CORS setup is needed on your side.
 * **Send the session cookie from the browser.** Calls to the Authentication Flow API made with `fetch()` must use `credentials: 'include'`, otherwise the session cookie is not sent and the option never appears.
 
+```mermaid
+flowchart TD
+    subgraph samesite ["example.com — same registrable domain"]
+        authgear["Authgear<br/>auth.example.com"]
+        uia["Custom UI of App A<br/>ui-a.example.com"]
+        uib["Custom UI of App B<br/>ui-b.example.com"]
+    end
+    other["Custom UI on an unrelated domain<br/>ui.other-domain.io"]
+
+    uia -- "session cookie sent,<br/>select_account offered" --> authgear
+    uib -- "session cookie sent,<br/>select_account offered" --> authgear
+    other -. "cookie never sent,<br/>option never appears" .-> authgear
+```
+
 {% hint style="info" %}
 If your Custom UI has separate sign-in and sign-up screens, its **first** call to create a flow must be of type `login` or `signup_login` — never `signup` directly. `select_account` only exists in those two flow types, so starting with `signup` means you never find out that a session exists. Create a separate `signup` flow afterward only if the user has no eligible session (or declines it) and wants a new account.
 {% endhint %}
+
+## How it works
+
+The select-account exchange sits inside the same OAuth flow every Custom UI already follows — the only new parts are the extra option in the `identify` response and the one-click input that completes it:
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant CustomUI as Custom UI (ui.example.com)
+    participant Authgear as Authgear (auth.example.com)
+
+    Note over App,Authgear: The browser already holds an Authgear session cookie
+    App->>Authgear: GET /oauth2/authorize?client_id=...
+    Authgear-->>CustomUI: 302 to Custom UI URI (client_id, x_ref, ...)
+    CustomUI->>Authgear: POST /api/v1/authentication_flows<br/>fetch with credentials: 'include' — cookie sent (same-site)
+    Authgear-->>CustomUI: identify options include select_account<br/>(display_name, user_id)
+    Note over CustomUI: Render "Continue as user@example.com"
+    CustomUI->>Authgear: POST /api/v1/authentication_flows/states/input<br/>{ "identification": "select_account", "index": 0 }
+    Authgear-->>CustomUI: action.type: finished (finish_redirect_uri)
+    CustomUI->>Authgear: Top-level navigation to finish_redirect_uri
+    Authgear-->>App: 302 to redirect_uri with authorization code
+    App->>Authgear: POST /oauth2/token (exchange code for tokens)
+```
+
+The user never typed a credential — the only interaction was the click on "Continue as user@example.com". When there is no eligible session, the third step's response simply has no `select_account` entry and your UI proceeds as a normal login.
 
 ## Step 1: Add select\_account to your flow config
 

--- a/reference/apis/authentication-flow-api.md
+++ b/reference/apis/authentication-flow-api.md
@@ -959,7 +959,7 @@ In some cases, the user may be unable to grant authorization successfully. In su
 
 ### 3.5 identification: select\_account
 
-The `select_account` option lets a user who already has an active Authgear session continue as that account without re-entering credentials. It can appear in the `identify` step of `login` and `signup_login` flows only, and only when the flow config lists it and the request carries an eligible session cookie. When there is no eligible session, the option is simply absent from `options`. See [Single Sign-On Continuation with Custom UI](../../customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md) for the full guide.
+The `select_account` option lets a user who already has an active Authgear session continue as that account without re-entering credentials. It can appear in the `identify` step of `login` and `signup_login` flows only, and only when the flow config lists it and the request carries an eligible session cookie. When there is no eligible session, the option is absent from `options`. See [Single Sign-On Continuation with Custom UI](../../customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md) for the full guide.
 
 Presence in response:
 
@@ -972,7 +972,7 @@ Presence in response:
 ```
 
 * `display_name`: A human-readable name for the account bound to the caller's session, suitable for a "Continue as user@example.com" button. Unlike `masked_display_name` elsewhere in this API, it is unmasked because it identifies the caller's own session.
-* `user_id`: The ID of the user this option would select. Informational only — it is never accepted as input. Use it if your UI wants to compare the option against a `login_hint` or `id_token_hint` it resolved itself.
+* `user_id`: The ID of the user this option would select. Informational only; it is never accepted as input. Use it if your UI wants to compare the option against a `login_hint` or `id_token_hint` it resolved itself.
 
 Usage in input:
 

--- a/reference/apis/authentication-flow-api.md
+++ b/reference/apis/authentication-flow-api.md
@@ -957,6 +957,36 @@ In some cases, the user may be unable to grant authorization successfully. In su
 
 `error_description` and `error_uri` are optional.
 
+### 3.5 identification: select\_account
+
+The `select_account` option lets a user who already has an active Authgear session continue as that account without re-entering credentials. It can appear in the `identify` step of `login` and `signup_login` flows only, and only when the flow config lists it and the request carries an eligible session cookie. When there is no eligible session, the option is simply absent from `options`. See [Single Sign-On Continuation with Custom UI](../../customization/ui-customization/custom-ui/single-sign-on-continuation-with-custom-ui.md) for the full guide.
+
+Presence in response:
+
+```json
+{
+  "identification": "select_account",
+  "display_name": "user@example.com",
+  "user_id": "user_01J8ZC0M2N3P4Q5R6S7T8V9W0X"
+}
+```
+
+* `display_name`: A human-readable name for the account bound to the caller's session, suitable for a "Continue as user@example.com" button. Unlike `masked_display_name` elsewhere in this API, it is unmasked because it identifies the caller's own session.
+* `user_id`: The ID of the user this option would select. Informational only — it is never accepted as input. Use it if your UI wants to compare the option against a `login_hint` or `id_token_hint` it resolved itself.
+
+Usage in input:
+
+```json
+{
+  "identification": "select_account",
+  "index": 0
+}
+```
+
+* `index`: The position of the `select_account` entry in the `options` array of the current response.
+
+If the session changes between the option being shown and the input being submitted, the API returns a [SelectAccountSessionChanged](authentication-flow-api.md#id-6.9-selectaccountsessionchanged) error.
+
 ## 4.0 Input: Authentications
 
 Here we'll cover all the supported authentication methods (authenticators) and how to pass them as input.
@@ -1326,7 +1356,7 @@ The value of `error.reason` can be `ValidationFailed` when there's a missing req
 
 Another cause for a `ValidationFailed` error is an invalid format in the value of a required field or an invalid constant in a required field.&#x20;
 
-An example of an invalid constant is setting the value of `identification` to anything outside the allowed values (`email`, `phone`, `oauth`, `username`). Also, using a constant for any feature that is not supported by your current login methods may throw the same error. You can always find more specific details about the cause of the error in the `error.info` object.&#x20;
+An example of an invalid constant is setting the value of `identification` to anything outside the allowed values (`email`, `phone`, `oauth`, `username`, `select_account`). Also, using a constant for any feature that is not supported by your current login methods may throw the same error. You can always find more specific details about the cause of the error in the `error.info` object.&#x20;
 
 The following example shows a `ValidationFailed` error for when a user enters a string that's not the correct format for an email address:
 
@@ -1465,6 +1495,19 @@ This is a rare error that may occur due to improper inputs such as poorly format
         "reason": "UnexpectedError",
         "message": "unexpected error occurred",
         "code": 500
+    }
+```
+
+### 6.9 SelectAccountSessionChanged
+
+A `SelectAccountSessionChanged` error occurs when a [select\_account](authentication-flow-api.md#id-3.5-identification-select_account) input is submitted but the session no longer matches the account that was offered — for example, the user logged out or switched accounts in another tab between the two requests. Handle it by creating a new authentication flow and rendering the fresh response.
+
+```json
+"error": {
+        "name": "Unauthorized",
+        "reason": "SelectAccountSessionChanged",
+        "message": "session no longer matches the selected account",
+        "code": 401
     }
 ```
 


### PR DESCRIPTION
## Summary

Documents the new `select_account` identification option in the Authentication Flow API (authgear/authgear-server, spec: `docs/specs/custom-ui-select-account.md`), which lets a same-site Custom UI show a "Continue as user@example.com" screen when the browser already has an active Authgear session.

### New page

**Customization > Custom UI > Single Sign-On Continuation with Custom UI**
- Use cases: SSO continuation across apps in the same project; a single "Continue" entry point (`signup_login`)
- Prerequisites: same-site hosting / custom domain, Custom UI URI, `credentials: 'include'`
- Setup steps: flow config YAML, detecting the option (`display_name`, `user_id`), submitting by `index`, handling decline
- Variations: `signup_login` flows, requiring 2FA on continuation
- Enforcing `login_hint` / `id_token_hint` client-side via `user_id`
- `SelectAccountSessionChanged` error handling and when the option is omitted

### Edits to existing pages

- **Authentication Flow API overview**: hint about the new option in the `identify` response; note that `login_hint`/`id_token_hint` are now forwarded on the Custom UI redirect
- **Custom UI hub README** + **SUMMARY.md**: link the new page
- **API reference**: new §3.5 `identification: select_account` and §6.9 `SelectAccountSessionChanged`; add `select_account` to the allowed identification values in §6.2

## Status

Ready. API shapes verified against the server implementation (`display_name`/`user_id` fields, `index` input, error name). Diagrams added as native Mermaid blocks (sequence diagram in "How it works", shared-Custom-UI same-site topology under Prerequisites), validated with mermaid-cli. Editorial pass applied. Portal screenshots for the flow-config step can follow up in a later PR.
