### PR TITLE
Add Fraud Protection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ description: >-
 
 # Authgear Overview
 
-**Authgear** is an authentication & user management solution which makes it very easy for developers to integrate and customize their consumer applications, it includes these features out of the box:
+**Authgear** is an authentication & user management solution that makes it very easy for developers to integrate and customize their consumer applications. It includes these features out of the box:
 
 * Zero trust authentication architecture with [OpenID Connect](https://openid.net/developers/how-connect-works/) (OIDC) standard.
-* Easy-to-use interfaces for user registration and login, including email, phone, username as login ID, and password, OTP, magic links, etc for authentication.
-* Support a wide range of identity providers, such as [Google](https://developers.google.com/identity), [Apple](https://support.apple.com/en-gb/guide/deployment/depa64848f3a/web), and [Azure Active Directory](https://azure.microsoft.com/en-gb/products/active-directory/) (AD).
-* Support biometric login on mobile, Passkeys, and Multi-Factor Authentication (MFA) such as SMS/email-based verification and authenticator apps with TOTP.
-* A user management portal, like password resets, account locking, scheduled deletion or anonymization, and user profile management.
+* Easy-to-use interfaces for user registration and login, including email, phone, username as login ID, and password, OTP, magic links, etc. for authentication.
+* Supports a wide range of identity providers, such as [Google](https://developers.google.com/identity), [Apple](https://support.apple.com/en-gb/guide/deployment/depa64848f3a/web), and [Azure Active Directory](https://azure.microsoft.com/en-gb/products/active-directory/) (AD).
+* Supports biometric login on mobile, Passkeys, and Multi-Factor Authentication (MFA) such as SMS/email-based verification and authenticator apps with TOTP.
+* A user management portal for password resets, account locking, scheduled deletion or anonymization, and user profile management.
 * Single Sign-On (SSO) provides a single unified experience for your customers to log into multiple web/mobile apps, including Web2Web, Web2App, and App2App SSO.
 * Enable [SSO with SAML](authentication-and-access/single-sign-on/single-sign-on-with-saml/) for your users to log into multiple web applications easily.
 * [Session management](authentication-and-access/sessions.md) with Authgear Portal, and a pre-built setting page for users to control concurrent sessions.
 * Customizable UI with a **user-friendly low-code** dashboard.
 * Various security features such as audit logs, brute force protection, smart account lockout, password policy, etc.
-* APIs for further integration and customizations. For example, build your own custom login and sign-up pages from the ground up powered by [Authentication Flow API](https://docs.authgear.com/~/changes/anTCj6yoZ06s3pLJk5v8/reference/apis/authentication-flow-api).
+* APIs for further integration and customization. For example, build your own custom login and sign-up pages from the ground up powered by the [Authentication Flow API](reference/apis/authentication-flow-api.md).
 
 Most importantly, you can [get started](https://accounts.portal.authgear.com/signup) **with Authgear for free**.
 
@@ -29,22 +29,22 @@ Authgear contains the following high-level components:
 #### Authenticate on the Web/Mobile App
 
 * **Client App SDKs** - for developers to quickly implement authentication with Auth UI on your web and mobile applications. Check out [Start Building](get-started/start-building.md) for tutorials and API References.
-* **Auth UI** - is the default batteries included UI for login, signup and setting page. You can customize the style via the **Portal**, including the CSS and HTML of each pag&#x65;**.**
-* [**Authentication Flow API**](customization/ui-customization/custom-ui/authentication-flow-api.md) - for developers to implement their own login, signup and reauthenticate UI (e.g. a mobile native view); or to define a customized login, signup and reauth flow.
-* [**Use Authgear as OpenID Connect Provider**](authentication-and-access/single-sign-on/oidc-provider.md) - for developers to use Authgear with other software that already support OIDC login, you can use Authgear as an OpenID Connect Provider.
+* **Auth UI** - the default batteries-included UI for login, signup and the settings page. You can customize the style via the **Portal**, including the CSS and HTML of each page.
+* [**Authentication Flow API**](customization/ui-customization/custom-ui/authentication-flow-api.md) - for developers to implement their own login, signup and reauthentication UI (e.g. a mobile native view); or to define a customized login, signup and reauth flow.
+* [**Use Authgear as OpenID Connect Provider**](authentication-and-access/single-sign-on/oidc-provider.md) - for developers to use Authgear with other software that already supports OIDC login, you can use Authgear as an OpenID Connect Provider.
 
 #### Backend Authentication and Integrations
 
-* [**Backend/API Integration**](get-started/backend-api/) - explain the common approach of using Access Token or Cookies (JWT or random string) to authenticate an API or HTTP Requests.
-* [**Admin API**](reference/apis/admin-api/) - allow your backend to interact directly with Authgear for user management purpose.
-* [**Events and Hooks**](customization/events-hooks/) - call external web endpoint or use the hosted type-script to customize the behaviour of Authgear. E.g. blocking certain type of sign up, or call external endpoint for each login.
+* [**Backend/API Integration**](get-started/backend-api/) - explains the common approach of using Access Tokens or Cookies (JWT or random string) to authenticate API or HTTP requests.
+* [**Admin API**](reference/apis/admin-api/) - allows your backend to interact directly with Authgear for user management purposes.
+* [**Events and Hooks**](customization/events-hooks/) - call an external web endpoint or use hosted TypeScript to customize the behaviour of Authgear, e.g. blocking certain types of sign-up, or calling an external endpoint on each login.
 * [**User Import API**](admin/user-management/import-users-using-user-import-api.md) - Import multiple users from another service to your project.
 * [**Export User API**](admin/user-management/export-users-using-the-user-export-api.md) - Export user data from Authgear into a CSV or [ndjson](https://github.com/ndjson/ndjson-spec) file.
 * [**Link OAuth Provider using Account Management API**](customization/ui-customization/custom-ui/manually-link-oauth-provider-using-account-management-api.md) - Link an OAuth provider to a user's account without AuthUI.
 
 #### Management Portal
 
-* **Authgear Portal** - You can configure your projects, manage users, check out [audit log](admin/monitor/audit-log.md), or customize the **AuthUI.** See the [5-minute quick start guide](get-started/5-minute-guide.md) for Authgear Portal.
+* **Authgear Portal** - You can configure your projects, manage users, check out [audit log](admin/monitor/audit-log.md), or customize the **AuthUI**. See the [5-minute quick start guide](get-started/5-minute-guide.md) for Authgear Portal.
 * **Analytics Page** - View reports of all users and active users over a specific time interval on the [analytics page](admin/monitor/analytics.md).
 
 #### Security

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Authgear contains the following high-level components:
 
 * [**Brute-force Protection**](security/brute-force-protection.md) - Set account Lockout Policy to safeguard a user account from brute-force login attempts.
 * [**Bot Protection**](security/bot-protection.md) - Bot protection tools to block automated attackers.
+* [**Fraud Protection**](security/fraud-protection.md) - Detect and stop fraudulent traffic such as SMS pumping before it drives up your messaging costs.
 * [**Password Strength**](authentication-and-access/authentication/passwords/password-policy.md) - Learn how to set password strength and how the password strength is calculated.
 
 #### Login Methods

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ description: >-
 * A user management portal, like password resets, account locking, scheduled deletion or anonymization, and user profile management.
 * Single Sign-On (SSO) provides a single unified experience for your customers to log into multiple web/mobile apps, including Web2Web, Web2App, and App2App SSO.
 * Enable [SSO with SAML](authentication-and-access/single-sign-on/single-sign-on-with-saml/) for your users to log into multiple web applications easily.
-* Session management with Authgear Portals, and a pre-built setting page for users to control concurrent sessions.
+* [Session management](authentication-and-access/sessions.md) with Authgear Portal, and a pre-built setting page for users to control concurrent sessions.
 * Customizable UI with a **user-friendly low-code** dashboard.
 * Various security features such as audit logs, brute force protection, smart account lockout, password policy, etc.
 * APIs for further integration and customizations. For example, build your own custom login and sign-up pages from the ground up powered by [Authentication Flow API](https://docs.authgear.com/~/changes/anTCj6yoZ06s3pLJk5v8/reference/apis/authentication-flow-api).

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -168,6 +168,7 @@
 
 * [Brute-force Protection](security/brute-force-protection.md)
 * [Bot Protection](security/bot-protection.md)
+* [Fraud Protection](security/fraud-protection.md)
 * [IP Blocklist](security/ip-blocklist.md)
 * [Non-HTTP scheme redirect URI](security/redirect-uri.md)
 * [Sender Constraining](security/sender-constraining.md)

--- a/security/fraud-protection.md
+++ b/security/fraud-protection.md
@@ -6,23 +6,23 @@ description: >-
 
 # Fraud Protection
 
-Fraud Protection detects and mitigates fraudulent activity in your authentication flows. It evaluates risk signals on each request, makes a decision (allow, flag, or block), and logs every decision with reason codes so you can see exactly what happened and why.
+Fraud Protection detects and mitigates fraudulent activity in your authentication flows. It evaluates risk signals on each request, makes a decision (allow, flag, or block), and logs every decision with reason codes so you can see what happened and why.
 
-The current release focuses on **SMS pumping detection**. More risk signals are on the roadmap, see [What's next](fraud-protection.md#whats-next).
+The current release focuses on **SMS pumping detection**. More risk signals are on the roadmap; see [What's next](fraud-protection.md#whats-next).
 
-You can find Fraud Protection in **Authgear Portal** > **Attack Protection** > **Fraud Protection**.
+Find Fraud Protection in **Authgear Portal** > **Attack Protection** > **Fraud Protection**.
 
 ## SMS Pumping Detection
 
-SMS pumping is a fraud scheme where attackers use bots to trigger large volumes of SMS one-time passwords (OTPs) to phone numbers they control or profit from. The OTPs are never verified. The goal is simply to make you send as many SMS as possible and inflate your messaging bill.
+SMS pumping is a fraud scheme where attackers use bots to request large volumes of SMS one-time passwords (OTPs) for phone numbers they control or profit from. The OTPs are never verified. The goal is to make you send as many messages as possible and inflate your SMS bill.
 
 Fraud Protection detects SMS pumping by watching for its telltale patterns on every SMS OTP request:
 
-* **Unverified OTPs by IP**: An unusually high ratio of OTPs requested from the same IP address that are never verified, within an hour or a day.
+* **Unverified OTPs by IP**: An unusually high ratio of unverified OTPs requested from the same IP address, within an hour or a day.
 * **Unverified OTPs by phone country**: An unusually high ratio of unverified OTPs sent to phone numbers of the same country, within an hour or a day.
 * **Phone countries by IP**: A single IP address requesting OTPs for phone numbers across an unusually large number of countries within a day.
 
-When a request trips any of these signals, it is flagged (or blocked, depending on the [mode](fraud-protection.md#modes)) and logged with the corresponding reason codes.
+When a request trips any of these signals, it is flagged (or blocked, depending on the [mode](fraud-protection.md#modes)) and logged with the reason codes.
 
 ## Modes
 
@@ -39,19 +39,19 @@ Start with Observe mode and review the Overview and Logs tabs for a while. Once 
 
 Configure Fraud Protection in the **Settings** tab:
 
-* **Enable Fraud Protection**: Turn the feature on or off. When disabled, no detection or logging takes place.
+* **Enable Fraud Protection**: Turn the feature on or off. When off, Authgear detects and logs nothing.
 * **Mode**: Choose between Observe mode and Protect mode.
-* **Allowlist Settings**: Requests matching an allowlist are never blocked, even in Protect mode. Use this to protect known-good traffic, such as your office network or internal test numbers.
+* **Allowlist Settings**: Requests matching an allowlist are never blocked, even in Protect mode. Use this to exempt known-good traffic, such as your office network or internal test numbers.
   * **IP Allowlist**: A list of IP addresses or CIDR ranges.
-  * **Allowed countries by Geo IP**: Requests from these countries, by IP geolocation, are not blocked.
+  * **Allow the following countries based on Geo IP**: Requests from these countries, by IP geolocation, are not blocked.
   * **Phone Number Allowlist**: A list of full phone numbers (e.g. `+85212345678`) or regular expression patterns.
-  * **Allowed countries by phone country code**: Requests to phone numbers registered in these countries are not blocked.
+  * **Allow the following countries based on phone country code**: Requests to phone numbers registered in these countries are not blocked.
 
-Detection thresholds are managed by Authgear with sensible defaults, so it works out of the box without tuning. To change the defaults, [contact us](https://www.authgear.com/talk-with-us).
+Authgear manages the detection thresholds, so there is nothing to tune. To change the defaults for your project, [contact us](https://www.authgear.com/talk-with-us).
 
 ## Monitoring
 
-Fraud Protection gives you full visibility into what it is doing:
+Two tabs show what Fraud Protection is doing:
 
 * **Overview** tab: Total SMS OTP requests with flagged and blocked counts, a requests-by-action chart over time, and breakdowns of top source IPs, SMS destinations by recipient phone country, and source IP locations.
 * **Logs** tab: Every decision as a queryable event, with the timestamp, action, result (Allow, Flagged, or Blocked), reason codes, source IP and its country, and the target phone number and its country. Open an entry to inspect the details, including the raw event log.

--- a/security/fraud-protection.md
+++ b/security/fraud-protection.md
@@ -1,0 +1,65 @@
+---
+description: >-
+  Detect and stop fraudulent traffic such as SMS pumping before it drives up
+  your messaging costs.
+---
+
+# Fraud Protection
+
+Fraud Protection detects and mitigates fraudulent activity in your authentication flows. It evaluates risk signals on each request, makes a decision (allow, flag, or block), and logs every decision with reason codes so you can see exactly what happened and why.
+
+The current release focuses on **SMS pumping detection**. More risk signals are on the roadmap, see [What's next](fraud-protection.md#whats-next).
+
+You can find Fraud Protection in **Authgear Portal** > **Attack Protection** > **Fraud Protection**.
+
+## SMS Pumping Detection
+
+SMS pumping is a fraud scheme where attackers use bots to trigger large volumes of SMS one-time passwords (OTPs) to phone numbers they control or profit from. The OTPs are never verified. The goal is simply to make you send as many SMS as possible and inflate your messaging bill.
+
+Fraud Protection detects SMS pumping by watching for its telltale patterns on every SMS OTP request:
+
+* **Unverified OTPs by IP**: An unusually high ratio of OTPs requested from the same IP address that are never verified, within an hour or a day.
+* **Unverified OTPs by phone country**: An unusually high ratio of unverified OTPs sent to phone numbers of the same country, within an hour or a day.
+* **Phone countries by IP**: A single IP address requesting OTPs for phone numbers across an unusually large number of countries within a day.
+
+When a request trips any of these signals, it is flagged (or blocked, depending on the [mode](fraud-protection.md#modes)) and logged with the corresponding reason codes.
+
+## Modes
+
+Fraud Protection runs in one of two modes:
+
+* **Observe mode** (default): Risky requests are flagged and logged, but not blocked. Use this to monitor fraud signals and confirm that legitimate users are not affected before enforcing rules.
+* **Protect mode**: Risky requests are blocked in real time.
+
+{% hint style="info" %}
+Start with Observe mode and review the Overview and Logs tabs for a while. Once you are confident the flagged traffic is genuinely fraudulent, switch to Protect mode.
+{% endhint %}
+
+## Settings
+
+Configure Fraud Protection in the **Settings** tab:
+
+* **Enable Fraud Protection**: Turn the feature on or off. When disabled, no detection or logging takes place.
+* **Mode**: Choose between Observe mode and Protect mode.
+* **Allowlist Settings**: Requests matching an allowlist are never blocked, even in Protect mode. Use this to protect known-good traffic, such as your office network or internal test numbers.
+  * **IP Allowlist**: A list of IP addresses or CIDR ranges.
+  * **Allowed countries by Geo IP**: Requests from these countries, by IP geolocation, are not blocked.
+  * **Phone Number Allowlist**: A list of full phone numbers (e.g. `+85212345678`) or regular expression patterns.
+  * **Allowed countries by phone country code**: Requests to phone numbers registered in these countries are not blocked.
+
+Detection thresholds are managed by Authgear with sensible defaults, so it works out of the box without tuning. To change the defaults, [contact us](https://www.authgear.com/talk-with-us).
+
+## Monitoring
+
+Fraud Protection gives you full visibility into what it is doing:
+
+* **Overview** tab: Total SMS OTP requests with flagged and blocked counts, a requests-by-action chart over time, and breakdowns of top source IPs, SMS destinations by recipient phone country, and source IP locations.
+* **Logs** tab: Every decision as a queryable event, with the timestamp, action, result (Allow, Flagged, or Blocked), reason codes, source IP and its country, and the target phone number and its country. Open an entry to inspect the details, including the raw event log.
+
+## What's next
+
+SMS pumping detection is the first phase of Fraud Protection. On the roadmap:
+
+* More risk signals, such as device fingerprinting and other bot activity indicators.
+* Challenges (e.g. CAPTCHA) as an enforcement option for risky requests, in addition to allow and block.
+* Configurable risk levels and external risk signals.

--- a/security/fraud-protection.md
+++ b/security/fraud-protection.md
@@ -47,7 +47,7 @@ Configure Fraud Protection in the **Settings** tab:
   * **Phone Number Allowlist**: A list of full phone numbers (e.g. `+85212345678`) or regular expression patterns.
   * **Allow the following countries based on phone country code**: Requests to phone numbers registered in these countries are not blocked.
 
-Authgear manages the detection thresholds, so there is nothing to tune. To change the defaults for your project, [contact us](https://www.authgear.com/talk-with-us).
+Detection thresholds are managed by Authgear with sensible defaults, so it works out of the box without tuning. To change the defaults, [contact us](https://www.authgear.com/talk-with-us).
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary

Documents the new **Attack Protection > Fraud Protection** feature.

- New page **Fraud Protection** (`security/fraud-protection.md`), placed in the *Security* section right after *Bot Protection*, mirroring the portal navigation. Covers:
  - **What it does**: evaluates risk signals per request, decides allow / flag / block, and logs every decision with reason codes.
  - **SMS pumping detection** (the current release): the three detection signals (unverified OTPs by IP, unverified OTPs by phone country, phone countries by IP).
  - **Modes**: Observe mode (flag and log only, default) and Protect mode (block in real time), with a recommendation to start in Observe.
  - **Settings**: enable toggle, mode, and the allowlists (IP/CIDR, Geo-IP countries, phone numbers/regex, phone country codes). Detection thresholds are managed by Authgear; changing defaults is via contact.
  - **Monitoring**: the Overview and Logs tabs.
  - **What's next**: further risk signals, challenges as an enforcement option, and configurable risk levels, per the roadmap. SMS pumping detection is the first phase.